### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitignore export-ignore
+.gitattributes export-ignore


### PR DESCRIPTION
By adding the .gitattributes file proposed here, which contains directives for excluding both .gitattributes and .gitignore, we avoid the inclusion of this later file in the release tarballs generated by GitHub.  Please, merge this change in the master branch, since the presence of the .gitignore file in the upstream tarball interferes with the Debian packaging.