### PR TITLE
Avoid errors when compiling with clang

### DIFF
--- a/LPC/Tube.cpp
+++ b/LPC/Tube.cpp
@@ -88,7 +88,7 @@ static void Tube_setLengths (Tube me, double length) {
 	}
 }
 
-void Tube_init (Tube me, double tmin, double tmax, long nt, double dt, double t1, long maxnSegments, double defaultLength) {
+static void Tube_init (Tube me, double tmin, double tmax, long nt, double dt, double t1, long maxnSegments, double defaultLength) {
 	my maxnSegments = maxnSegments;
 	Sampled_init (me, tmin, tmax, nt, dt, t1);
 	my frame = NUMvector<structTube_Frame> (1, nt);

--- a/LPC/Tube.h
+++ b/LPC/Tube.h
@@ -35,8 +35,6 @@ void Tube_Frame_free (Tube_Frame me);
 
 void Tube_Frames_rc_into_area (Tube_Frame me, Tube_Frame thee);
 
-void Tube_init (Tube me, double tmin, double tmax, long nt, double dt, double t1, long maxnSegments, double defaultLength);
-
 Thing_define (Area, Tube) {
 };
 

--- a/dwtools/CC.cpp
+++ b/dwtools/CC.cpp
@@ -200,11 +200,6 @@ double CC_getValueInFrame (CC me, long iframe, long index) {
 	return index > cf -> numberOfCoefficients ? NUMundefined : cf -> c[index];
 }
 
-static double CC_getValueAtTime (CC me, double t, long index) {
-	long iframe = Sampled_xToNearestIndex (me, t);
-	return CC_getValueInFrame (me, iframe, index);
-}
-
 double CC_getValue (CC me, double t, long index) {
 	long iframe = Sampled_xToNearestIndex (me, t);
 	if (iframe < 1 || iframe > my nx) {
@@ -220,11 +215,6 @@ double CC_getC0ValueInFrame (CC me, long iframe) {
 	}
 	CC_Frame cf = & me -> frame[iframe];
 	return cf -> c0;
-}
-
-double CC_getC0ValueAtTime (CC me, double t) {
-	long iframe = Sampled_xToNearestIndex (me, t);
-	return CC_getC0ValueInFrame (me, iframe);
 }
 
 /* End of file CC.cpp */

--- a/dwtools/Minimizers.cpp
+++ b/dwtools/Minimizers.cpp
@@ -156,11 +156,6 @@ void Minimizer_minimizeManyTimes (Minimizer me, long numberOfTimes, long maxIter
 	Minimizer_reset (me, popt.peek());
 }
 
-void Minimizer_setAfterEachIteration (Minimizer me, void (*afterHook) (Minimizer me, Thing afterBoss), Thing afterBoss) {
-	my afterHook = afterHook;
-	my afterBoss = afterBoss;
-}
-
 void Minimizer_reset (Minimizer me, const double guess[]) {
 	if (guess) {
 		for (long i = 1; i <= my nParameters; i++) {

--- a/dwtools/Minimizers.h
+++ b/dwtools/Minimizers.h
@@ -74,9 +74,6 @@ void Minimizer_reset (Minimizer me, const double guess[]);
  *    reset (me);
  */
 
-void Minimizer_setAfterEachIteration (Minimizer me, int (*afterHook) (Minimizer me, Thing afterBoss), Thing afterBoss);
-/* set the procedure that is executed after each iteration. */
-
 void Minimizer_minimize (Minimizer me, long maxNumOfIterations, double tolerance, int monitor);
 /* Minimizes during maximally maxNumOfIterations. The gmonitor is initialized
  * before minimization and cleared afterwards.

--- a/external/espeak/compiledict.cpp
+++ b/external/espeak/compiledict.cpp
@@ -32,7 +32,6 @@
 #include "translate.h"
 
 extern void Write4Bytes(FILE *f, int value);
-int HashDictionary(const char *string);
 
 static FILE *f_log = NULL;
 extern char *dir_dictionary;
@@ -182,7 +181,7 @@ static FILE *fopen_log(const char *fname,const char *access)
 }
 
 
-const char *LookupMnemName(MNEM_TAB *table, const int value)
+static const char *LookupMnemName(MNEM_TAB *table, const int value)
 //==========================================================
 /* Lookup a mnemonic string in a table, return its name */
 {
@@ -917,7 +916,7 @@ static int group3_ix;
 
 
 
-int isHexDigit(int c)
+static int isHexDigit(int c)
 {
 	if((c >= '0') && (c <= '9'))
 		return(c - '0');
@@ -1387,7 +1386,7 @@ static char *compile_rule(char *input)
 }  //  end of compile_rule
 
 
-int string_sorter(char **a, char **b)
+static int string_sorter(char **a, char **b)
 {//===========================================
 	char *pa, *pb;
 	int ix;

--- a/external/espeak/klatt.cpp
+++ b/external/espeak/klatt.cpp
@@ -1064,7 +1064,7 @@ static double klattp_inc[N_KLATTP];
 
 
 
-int Wavegen_Klatt(int resume)
+static int Wavegen_Klatt(int resume)
 {//==========================
 	int pk;
 	int x;
@@ -1183,7 +1183,7 @@ int Wavegen_Klatt(int resume)
 }
 
 
-void SetSynth_Klatt(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *v, int control)
+static void SetSynth_Klatt(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *v, int control)
 {//===========================================================================================
 	int ix;
 	DOUBLEX next;

--- a/external/espeak/numbers.cpp
+++ b/external/espeak/numbers.cpp
@@ -586,7 +586,7 @@ static const int number_ranges[] = {
 	0 };  // these must be in ascending order
 
 
-int NonAsciiNumber(int letter)
+static int NonAsciiNumber(int letter)
 {//============================
 // Change non-ascii digit into ascii digit '0' to '9', (or -1 if not)
 	const int *p;
@@ -1974,7 +1974,7 @@ static int LookupNum3(Translator *tr, int value, char *ph_out, int suppress_null
 }  // end of LookupNum3
 
 
-bool CheckThousandsGroup(char *word, int group_len)
+static bool CheckThousandsGroup(char *word, int group_len)
 {//================================================
 // Is this a group of 3 digits which looks like a thousands group?
 	int ix;

--- a/external/espeak/readclause.cpp
+++ b/external/espeak/readclause.cpp
@@ -1528,7 +1528,7 @@ static int attr_prosody_value(int param_type, const wchar_t *pw, int *value_out)
 }  // end of attr_prosody_value
 
 
-int AddNameData(const char *name, int wide)
+static int AddNameData(const char *name, int wide)
 {//========================================
 // Add the name to the namedata and return its position
 // (Used by the Windows SAPI wrapper)

--- a/external/espeak/setlengths.cpp
+++ b/external/espeak/setlengths.cpp
@@ -30,8 +30,6 @@
 #include "voice.h"
 #include "translate.h"
 
-extern int GetAmplitude(void);
-extern void DoSonicSpeed(int value);
 extern int saved_parameters[];
 
 

--- a/external/espeak/speak_lib.cpp
+++ b/external/espeak/speak_lib.cpp
@@ -762,11 +762,6 @@ ESPEAK_API void espeak_SetUriCallback(int (* UriCallback)(int, const char*, cons
 }
 
 
-ESPEAK_API void espeak_SetPhonemeCallback(int (* PhonemeCallback)(const char*))
-{//===========================================================================
-	phoneme_callback = PhonemeCallback;
-}
-
 ESPEAK_API int espeak_Initialize(espeak_AUDIO_OUTPUT output_type, int buf_length, const char *path, int options)
 {//=============================================================================================================
 ENTER("espeak_Initialize");
@@ -1251,9 +1246,6 @@ ESPEAK_API espeak_ERROR espeak_Synchronize(void)
 	return berr;
 }   //  end of espeak_Synchronize
 
-
-extern void FreePhData(void);
-extern void FreeVoiceList(void);
 
 ESPEAK_API espeak_ERROR espeak_Terminate(void)
 {//===========================================

--- a/external/espeak/synth_mbrola.cpp
+++ b/external/espeak/synth_mbrola.cpp
@@ -40,7 +40,6 @@ int option_mbrola_phonemes;
 #ifdef INCLUDE_MBROLA
 
 extern int Read4Bytes(FILE *f);
-extern void SetPitch2(voice_t *voice, int pitch1, int pitch2, int *pitch_base, int *pitch_range);
 extern unsigned char *outbuf;
 
 #ifndef PLATFORM_WINDOWS

--- a/external/espeak/synthdata.cpp
+++ b/external/espeak/synthdata.cpp
@@ -67,8 +67,6 @@ int vowel_transition[4];
 int vowel_transition0;
 int vowel_transition1;
 
-int FormantTransition2(frameref_t *seq, int *n_frames, unsigned int data1, unsigned int data2, PHONEME_TAB *other_ph, int which);
-
 
 
 static char *ReadPhFile(void *ptr, const char *fname, int *size)

--- a/external/espeak/synthesize.h
+++ b/external/espeak/synthesize.h
@@ -518,6 +518,7 @@ frameref_t *LookupSpect(PHONEME_TAB *this_ph, int which, FMT_PARAMS *fmt_params,
 
 unsigned char *LookupEnvelope(int ix);
 int LoadPhData(int *srate);
+void FreePhData(void);
 
 void SynthesizeInit(void);
 int  Generate(PHONEME_LIST *phoneme_list, int *n_ph, int resume);
@@ -533,6 +534,8 @@ int  SelectPhonemeTableName(const char *name);
 void Write4Bytes(FILE *f, int value);
 int Read4Bytes(FILE *f);
 int Reverse4Bytes(int word);
+void print_dictionary_flags(unsigned int *flags, char *buf, int buf_len);
+char *DecodeRule(const char *group_chars, int group_length, char *rule, int control);
 int CompileDictionary(const char *dsource, const char *dict_name, FILE *log, char *err_name,int flags);
 
 
@@ -574,8 +577,10 @@ void MbrolaReset(void);
 void DoEmbedded(int *embix, int sourceix);
 void DoMarker(int type, int char_posn, int length, int value);
 void DoPhonemeMarker(int type, int char_posn, int length, char *name);
+void DoSonicSpeed(int value);
 int DoSample3(PHONEME_DATA *phdata, int length_mod, int amp);
 int DoSpect2(PHONEME_TAB *this_ph, int which, FMT_PARAMS *fmt_params,  PHONEME_LIST *plist, int modulation);
+int FormantTransition2(frameref_t *seq, int *n_frames, unsigned int data1, unsigned int data2, PHONEME_TAB *other_ph, int which);
 int PauseLength(int pause, int control);
 int LookupPhonemeTable(const char *name);
 unsigned char *GetEnvelope(int index);

--- a/external/espeak/tr_languages.cpp
+++ b/external/espeak/tr_languages.cpp
@@ -424,7 +424,7 @@ static void SetCyrillicLetters(Translator *tr)
 }  // end of SetCyrillicLetters
 
 
-void SetIndicLetters(Translator *tr)
+static void SetIndicLetters(Translator *tr)
 {//=================================
 	// Set letter types for Indic scripts, Devanagari, Tamill, etc
 	static const char dev_consonants2[] = {0x02,0x03,0x58,0x59,0x5a,0x5b,0x5c,0x5d,0x5e,0x5f,0x7b,0x7c,0x7e,0x7f,0};
@@ -450,7 +450,7 @@ void SetIndicLetters(Translator *tr)
 }
 
 
-void SetupTranslator(Translator *tr, const short *lengths, const unsigned char *amps)
+static void SetupTranslator(Translator *tr, const short *lengths, const unsigned char *amps)
 {//==================================================================================
 	if(lengths != NULL)
 		memcpy(tr->stress_lengths,lengths,sizeof(tr->stress_lengths));

--- a/external/espeak/translate.cpp
+++ b/external/espeak/translate.cpp
@@ -450,7 +450,7 @@ int IsDigit(unsigned int c)
 	return(0);
 }
 
-int IsSpace(unsigned int c)
+static int IsSpace(unsigned int c)
 {//========================
 	if(c == 0)
 		return(0);
@@ -619,19 +619,6 @@ char *strchr_w(const char *s, int c)
 }
 
 
-int IsAllUpper(const char *word)
-{//=============================
-	int c;
-	while((*word != 0) && !isspace2(*word))
-	{
-		word += utf8_in(&c, word);
-		if(!iswupper2(c))
-			return(0);
-	}
-	return(1);
-}
-
-
 static char *SpeakIndividualLetters(Translator *tr, char *word, char *phonemes, int spell_word)
 {//============================================================================================
 	int posn = 0;
@@ -727,7 +714,7 @@ static int CheckDottedAbbrev(char *word1, WORD_TAB *wtab)
 
 extern char *phondata_ptr;
 
-int ChangeEquivalentPhonemes(Translator *tr, int lang2, char *phonemes)
+static int ChangeEquivalentPhonemes(Translator *tr, int lang2, char *phonemes)
 {//====================================================================
 // tr:  the original language
 // lang2:  phoneme table number for the temporary language
@@ -1677,7 +1664,7 @@ static int CountSyllables(unsigned char *phonemes)
 }
 
 
-void Word_EmbeddedCmd()
+static void Word_EmbeddedCmd()
 {//====================
 // Process embedded commands for emphasis, sayas, and break
 	int embedded_cmd;
@@ -2544,7 +2531,7 @@ static int TranslateChar(Translator *tr, char *ptr, int prev_in, unsigned int c,
 
 static const char *UCase_ga[] = {"bp","bhf","dt","gc","hA","mb","nd","ng","ts","tA","nA",NULL};
 
-int UpperCaseInWord(Translator *tr, char *word, int c)
+static int UpperCaseInWord(Translator *tr, char *word, int c)
 {//=====================================================
 	int ix;
 	int len;

--- a/external/espeak/translate.h
+++ b/external/espeak/translate.h
@@ -764,6 +764,7 @@ void LookupLetter(Translator *tr, unsigned int letter, int next_byte, char *ph_b
 void LookupAccentedLetter(Translator *tr, unsigned int letter, char *ph_buf);
 
 int LoadDictionary(Translator *tr, const char *name, int no_error);
+int HashDictionary(const char *string);
 int LookupDictList(Translator *tr, char **wordptr, char *ph_out, unsigned int *flags, int end_flags, WORD_TAB *wtab);
 
 void MakePhonemeList(Translator *tr, int post_pause, int new_sentence);

--- a/external/espeak/voice.h
+++ b/external/espeak/voice.h
@@ -84,4 +84,6 @@ void WVoiceChanged(voice_t *wvoice);
 void WavegenSetVoice(voice_t *v);
 void ReadTonePoints(char *string, int *tone_pts);
 void VoiceReset(int control);
-
+void FreeVoiceList(void);
+int GetAmplitude(void);
+void SetPitch2(voice_t *voice, int pitch1, int pitch2, int *pitch_base, int *pitch_range);

--- a/external/espeak/wavegen.cpp
+++ b/external/espeak/wavegen.cpp
@@ -854,7 +854,7 @@ static void WavegenSetEcho(void)
 
 
 
-int PeaksToHarmspect(wavegen_peaks_t *peaks, int pitch, int *htab, int control)
+static int PeaksToHarmspect(wavegen_peaks_t *peaks, int pitch, int *htab, int control)
 {//============================================================================
 // Calculate the amplitude of each  harmonics from the formants
 // Only for formants 0 to 5
@@ -1166,7 +1166,7 @@ static int ApplyBreath(void)
 
 
 
-int Wavegen()
+static int Wavegen()
 {//==========
 	unsigned short waveph;
 	unsigned short theta;
@@ -1690,7 +1690,7 @@ void SetPitch2(voice_t *voice, int pitch1, int pitch2, int *pitch_base, int *pit
 }
 
 
-void SetPitch(int length, unsigned char *env, int pitch1, int pitch2)
+static void SetPitch(int length, unsigned char *env, int pitch1, int pitch2)
 {//==================================================================
 // length in samples
 
@@ -1727,7 +1727,7 @@ if(option_log_frames)
 
 
 
-void SetSynth(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *v)
+static void SetSynth(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *v)
 {//========================================================================
 	int ix;
 	DOUBLEX next;
@@ -1862,7 +1862,7 @@ void Write4Bytes(FILE *f, int value)
 
 
 
-int WavegenFill2(int fill_zeros)
+static int WavegenFill2(int fill_zeros)
 {//============================
 // Pick up next wavegen commands from the queue
 // return: 0  output buffer has been filled

--- a/sys/melder_audio.cpp
+++ b/sys/melder_audio.cpp
@@ -600,7 +600,7 @@ static int thePaStreamCallback (const void *input, void *output,
 }
 
 #ifdef HAVE_PULSEAUDIO
-void pulseAudio_initialize () {
+static void pulseAudio_initialize () {
 	struct MelderPlay *me = & thePlay;
 	if (! my pulseAudio.pulseAudioInitialized) {
 		my pulseAudio.mainloop = pa_threaded_mainloop_new ();
@@ -646,7 +646,7 @@ void pulseAudio_cleanup () {
 	my pulseAudio.pulseAudioInitialized = false;
 }
 
-void pulseAudio_server_info_cb (pa_context *context, const pa_server_info *info, void *userdata) {
+static void pulseAudio_server_info_cb (pa_context *context, const pa_server_info *info, void *userdata) {
 	struct MelderPlay *me = (struct MelderPlay *) userdata;
 	if (! info) {
 		return;
@@ -680,6 +680,7 @@ void pulseAudio_server_info_cb (pa_context *context, const pa_server_info *info,
 	pa_threaded_mainloop_signal (my pulseAudio.mainloop, 0);
 }
 
+void pulseAudio_serverReport (void);
 void pulseAudio_serverReport () {
 	// TODO: initiaize context
 	struct MelderPlay *me = & thePlay;
@@ -768,7 +769,7 @@ static void free_cb(void * /* p */) { // to prevent copying of data
 }
 
 // asynchronous version
-void stream_write_cb2 (pa_stream *stream, size_t length, void *userdata) {
+static void stream_write_cb2 (pa_stream *stream, size_t length, void *userdata) {
 	struct MelderPlay *me = (struct MelderPlay *) userdata;
 	if (stream == my pulseAudio.stream) {
 		//length = my pulseAudio.latency; // overrule length given by server
@@ -885,7 +886,7 @@ void stream_write_cb (pa_stream *stream, size_t length, void *userdata) {
 	}
 }
 
-void stream_state_cb (pa_stream *stream, void *userdata) {
+static void stream_state_cb (pa_stream *stream, void *userdata) {
 	struct MelderPlay *me = (struct MelderPlay *) userdata;
 
 	if (stream == my pulseAudio.stream) {


### PR DESCRIPTION
This commit fixes all the compilation errors that are triggered by the
option "-Werror=missing-prototypes", when compiling with clang instead
of gcc in Debian GN/Linux .  Most of the errors were caused by
functions that are locally defined but were lacking the "static"
specifier.  This is fixed by this commit.

Function declarations (either with or without the "extern" specifier)
appearing in *.cpp files have been deleted and moved into appropriate
*.h header files.  I hope I got them all right.

Some functions, which were defined but used nowhere, are removed.
They are:

  - CC_getValueAtTime and CC_getC0ValueAtTime (dwtools/CC.cpp)
  - Minimizer_setAfterEachIteration (dwtools/Minimizers.cpp)
  - espeak_SetPhonemeCallback (external/espeak/speak_lib.cpp)
  - IsAllUpper (external/espeak/translate.cpp)

Note that a similar patch [1] has been proposed for the Debian praat
package version 6.0.5-1, which closed Bug#812715 [2].  However, that
patch simply adds a function declaration before each function
definition. The present commit addresses the issue in a more elegant
way, I hope.

[1] https://anonscm.debian.org/cgit/debian-med/praat.git/commit/?id=b3356c3
[2] https://bugs.debian.org/812715