### PR TITLE
compile RBM.cpp in gram/Makefile

### DIFF
--- a/gram/Makefile
+++ b/gram/Makefile
@@ -8,7 +8,7 @@ CPPFLAGS = -I ../num -I ../kar -I ../sys -I ../dwsys -I ../stat -I ../dwtools -I
 OBJECTS = Network.o \
    OTGrammar.o OTGrammarEditor.o manual_gram.o praat_gram.o OTMulti.o OTMultiEditor.o \
    OTGrammar_ex_metrics.o OTGrammar_ex_NoCoda.o OTGrammar_ex_NPA.o OTGrammar_ex_tongueRoot.o \
-   OTMulti_ex_metrics.o
+   OTMulti_ex_metrics.o RBM.o
 
 .PHONY: all clean
 


### PR DESCRIPTION
Fix compile error due to RBM.cpp file is not in the gram/Makefile