### PR TITLE
sys/sendpraat.c: Conditionally use the deprecated function g_type_init

### DIFF
--- a/sys/sendpraat.c
+++ b/sys/sendpraat.c
@@ -234,7 +234,9 @@ char *sendpraat (void *display, const char *programName, long timeOut, const cha
 			 * Notify main window.
 			 */
 			GdkEventClient gevent;
+#if !GLIB_CHECK_VERSION(2,35,0)
 			g_type_init ();
+#endif
 			int displaySupplied = display != NULL;
 			if (! displaySupplied) {
 				display = gdk_display_open (getenv ("DISPLAY"));   /* GdkDisplay* */
@@ -458,7 +460,9 @@ wchar_t *sendpraatW (void *display, const wchar_t *programName, long timeOut, co
 			 */
 			GdkEventClient gevent;
 			int displaySupplied = display != NULL;
+#if !GLIB_CHECK_VERSION(2,35,0)
 			g_type_init ();
+#endif
 			if (! displaySupplied) {
 				display = gdk_display_open (getenv ("DISPLAY"));   /* GdkDisplay* */
 				if (display == NULL) {


### PR DESCRIPTION
The g_type_init function has been deprecated in version 2.35.0 of
GLib.  The use of this function in sendpraat.c is made conditional on
the version of GLib.
