### PR TITLE
changes for running praat on headless linux server

### DIFF
--- a/makefiles/makefile.defs.linuxs.pulse
+++ b/makefiles/makefile.defs.linuxs.pulse
@@ -15,7 +15,7 @@ LINK = g++
 
 EXECUTABLE = praat
 
-LIBS = -lm -lasound -lpthread
+LIBS = `pkg-config --libs gtk+-2.0` -lm -lpulse -lasound -lpthread
 
 AR = ar
 RANLIB = ls

--- a/sys/melder_audio.cpp
+++ b/sys/melder_audio.cpp
@@ -1202,7 +1202,9 @@ void MelderAudio_play16 (int16_t *buffer, long sampleRate, long numberOfSamples,
 			// without a timer, on my computer the workproc would be called almost once in every sampling period.
 			// Such frequent updates are not necessary, some 50 updates a second is fast enough for displayong a runnning cursor
 			// the timeout will be automatically stopped if workProc_gtk returns false.
+#ifndef NO_GRAPHICS
 			my workProcId_gtk = g_timeout_add (20, workProc_gtk, nullptr);
+#endif
 		}
 	#endif
 	} else {

--- a/sys/melder_debug.cpp
+++ b/sys/melder_debug.cpp
@@ -606,6 +606,7 @@ void Melder_trace (const char *fileName, int lineNumber, const char *functionNam
 }
 
 #ifdef linux
+#ifndef NO_GRAPHICS
 static void theGtkLogHandler (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer unused_data) {
 	FILE *f = Melder_trace_open (nullptr, 0, "GTK");
 	fprintf (f, "%s", message);
@@ -622,6 +623,7 @@ static void theGlibGobjectLogHandler (const gchar *log_domain, GLogLevelFlags lo
 	Melder_trace_close (f);
 }
 #endif
+#endif
 
 void Melder_setTracing (bool tracing) {
 	time_t today = time (nullptr);
@@ -634,6 +636,7 @@ void Melder_setTracing (bool tracing) {
 		);
 	Melder_isTracing = tracing;
 	#ifdef linux
+	#ifndef NO_GRAPHICS
 		static guint handler_id1, handler_id2, handler_id3;
 		if (tracing) {
 			handler_id1 = g_log_set_handler ("Gtk",          (GLogLevelFlags) (G_LOG_LEVEL_MASK | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION), theGtkLogHandler,         nullptr);
@@ -645,6 +648,7 @@ void Melder_setTracing (bool tracing) {
 			if (handler_id3) g_log_remove_handler ("GLib-GObject", handler_id3);
 			handler_id1 = handler_id2 = handler_id3 = 0;
 		}
+	#endif
 	#endif
 	if (tracing)
 		trace (U"switch tracing on"


### PR DESCRIPTION
Running praat on a headless linux server fails with Glib errors: http://stackoverflow.com/questions/38098717. Building from source using makefile.defs.linuxs.pulse solves the problem, but I had to do some changes for the build to succeed.
