### PR TITLE
Adding FFNet to Makefile for ola

### DIFF
--- a/contrib/ola/Makefile
+++ b/contrib/ola/Makefile
@@ -4,7 +4,7 @@
 
 include ../../makefile.defs
 
-CPPFLAGS = -I ../../dwtools -I ../../fon -I ../../sys -I ../../dwsys -I ../../stat -I ../../num -I ../../external/gsl -D_DEBUG -D_REENTRANT
+CPPFLAGS = -I ../../dwtools -I ../../fon -I ../../sys -I ../../dwsys -I ../../stat -I ../../num -I ../../external/gsl -I ../../FFNet -D_DEBUG -D_REENTRANT 
 
 OBJECTS = KNN.o \
    KNN_threads.o Pattern_to_Categories_cluster.o KNN_prune.o FeatureWeights.o praat_contrib_Ola_KNN.o manual_KNN.o


### PR DESCRIPTION
Need FFNet added to includes, build fails due to not including directory for praat_ffnet.h header file.