### PR TITLE
Fix typo in header include

### DIFF
--- a/sys/Formula.h
+++ b/sys/Formula.h
@@ -19,7 +19,7 @@
  */
 
 #include "Data.h"
-#include "tensor.h"
+#include "Tensor.h"
 
 #define kFormula_EXPRESSION_TYPE_NUMERIC  0
 #define kFormula_EXPRESSION_TYPE_STRING  1


### PR DESCRIPTION
The name of `sys/Tensor.h` was misspelled in `sys/Formula.h`.

Fixes #388 
