### PR TITLE
Use pkg-config for setting CFLAGS and LDFLAGS

### DIFF
--- a/makefiles/makefile.defs.linux.nogui
+++ b/makefiles/makefile.defs.linux.nogui
@@ -7,7 +7,7 @@ CC = gcc -std=gnu99
 
 CXX = g++ -std=c++11
 
-CFLAGS = -DNO_GUI -DNO_NETWORK -D_FILE_OFFSET_BITS=64 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/cairo -I/usr/include/pango-1.0 -DUNIX -Dlinux -Werror=missing-prototypes -Werror=implicit -Wreturn-type -Wunused -Wunused-parameter -Wuninitialized -O3 -g1 -pthread
+CFLAGS = -DNO_GUI -DNO_NETWORK -D_FILE_OFFSET_BITS=64 `pkg-config --cflags gtk+-2.0` -DUNIX -Dlinux -Werror=missing-prototypes -Werror=implicit -Wreturn-type -Wunused -Wunused-parameter -Wuninitialized -O3 -g1 -pthread
 
 CXXFLAGS = $(CFLAGS) -Wshadow
 
@@ -15,7 +15,7 @@ LINK = g++
 
 EXECUTABLE = praat_nogui
 
-LIBS = -lpangocairo-1.0 -lcairo -lpango-1.0 -lgobject-2.0 -lm -lpthread
+LIBS = `pkg-config --libs gtk+-2.0` -lm -lpthread
 
 AR = ar
 RANLIB = ls


### PR DESCRIPTION
This change allows the building in any architecture and is not restricted to x86_64. This is needed for building the Debain package for PRaat. And yes, version 6.0.30-* of the Debian package praat ships now with the praat_nogui executable! 