### PR TITLE
Use pkg-config for pangocairo cflags and libs

### DIFF
--- a/makefiles/makefile.defs.linux.nogui
+++ b/makefiles/makefile.defs.linux.nogui
@@ -7,7 +7,7 @@ CC = gcc -std=gnu99
 
 CXX = g++ -std=c++11
 
-CFLAGS = -DNO_GUI -DNO_NETWORK -D_FILE_OFFSET_BITS=64 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/cairo -I/usr/include/pango-1.0 -DUNIX -Dlinux -Werror=missing-prototypes -Werror=implicit -Wreturn-type -Wunused -Wunused-parameter -Wuninitialized -O3 -g1 -pthread
+CFLAGS = -DNO_GUI -DNO_NETWORK -D_FILE_OFFSET_BITS=64 `pkg-config --cflags pangocairo` -DUNIX -Dlinux -Werror=missing-prototypes -Werror=implicit -Wreturn-type -Wunused -Wunused-parameter -Wuninitialized -O3 -g1 -pthread
 
 CXXFLAGS = $(CFLAGS) -Wshadow
 
@@ -15,7 +15,7 @@ LINK = g++
 
 EXECUTABLE = praat_nogui
 
-LIBS = -lpangocairo-1.0 -lcairo -lpango-1.0 -lgobject-2.0 -lm -lpthread
+LIBS = `pkg-config --libs pangocairo` -lm -lpthread
 
 AR = ar
 RANLIB = ls


### PR DESCRIPTION
Use pkg-config instead of hardcoding pangocairo cflags and libs (gives the proper location instead of x86_64-linux-gnu in the include search path even on non-amd64).

This pull request replaces #416, which I just closed. Credits go to [Adrian Bunk](mailto:bunk@debian.org), who [proposed](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=871907) the patch in a bug report against the Debian package praat.
