### PR TITLE
Adding checks for number and type of arguments of READ and SAVE commands

### DIFF
--- a/sys/praat.h
+++ b/sys/praat.h
@@ -502,6 +502,8 @@ void praat_name2 (char32 *name, ClassInfo klas1, ClassInfo klas2);
 				if (! args && ! sendingString) { \
 					file = UiFile_getFile (dia); \
 				} else { \
+					Melder_require (! args || narg == 1, U"Command requires exactly 1 argument, the name of the file to read, instead of the given ", narg, U" arguments."); \
+					Melder_require (! args || args [1]. which == Stackel_STRING, U"The file name argument should be a string, not ", Stackel_whichText (& args [1]), U"."); \
 					Melder_relativePathToFile (args ? args [1]. string : sendingString, & _file2); \
 					file = & _file2; \
 				}
@@ -523,6 +525,8 @@ void praat_name2 (char32 *name, ClassInfo klas1, ClassInfo klas2);
 				if (! args && ! sendingString) { \
 					file = UiFile_getFile (dia); \
 				} else { \
+					Melder_require (! args || narg == 1, U"Command requires exactly 1 argument, the name of the file to write, instead of the given ", narg, U" arguments."); \
+					Melder_require (! args || args [1]. which == Stackel_STRING, U"The file name argument should be a string, not ", Stackel_whichText (& args [1]), U"."); \
 					Melder_relativePathToFile (args ? args [1]. string : sendingString, & _file2); \
 					file = & _file2; \
 				}


### PR DESCRIPTION
This PR would fix a Praat crash when running the simple script `Read from file: 1` by checking if the argument that was passed is a string before accessing the union's string field.

Next to that this also fixes the less harmful, but weird call `Read from file: "a.wav" "b.wav" "c.wav"` where all but the first argument are ignored (without error message).

Only `Read from file...` would still give reasonably unexpected, but harmless behaviour (i.e., trying to read the home directory).