### PR TITLE
Fixed typo in Table: Collapse rows

### DIFF
--- a/stat/praat_Stat.cpp
+++ b/stat/praat_Stat.cpp
@@ -903,7 +903,7 @@ FORM (NEW_Table_collapseRows, U"Table: Collapse rows", nullptr) {
 	TEXTFIELD (columnsToSum, U"Columns to sum:", U"number cost")
 	TEXTFIELD (columnsToAverage, U"Columns to average:", U"price")
 	TEXTFIELD (columnsToMedianize, U"Columns to medianize:", U"vot")
-	TEXTFIELD (columnsToAverageLogarithmically, U"olumns to average logarithmically:", U"duration")
+	TEXTFIELD (columnsToAverageLogarithmically, U"Columns to average logarithmically:", U"duration")
 	TEXTFIELD (columnsToMedianizeLogarithmically, U"Columns to medianize logarithmically:", U"F0 F1 F2 F3")
 	LABEL (U"Columns not mentioned above will be ignored.")
 	OK


### PR DESCRIPTION
`Table: Collapse rows` command has a field which says: 

`olumns to average logarithmically`

But, it should be:

`Columns to average logarithmically`

![image](https://user-images.githubusercontent.com/18198623/41804368-10d03682-765b-11e8-80dc-ecbd94f35891.png)


