### PR TITLE
quick fix for macOS 10.14 Mojave: disallow dark mode and use SDK 10.1…

### DIFF
--- a/main/praat.plist
+++ b/main/praat.plist
@@ -523,5 +523,7 @@
 	<string>Copyright © 1992-PRAAT_YEAR by Paul Boersma &amp; David Weenink</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
…3 (copy into Xcode 10 from an older version of Xcode)