### PR TITLE
pa_jack.c: fix conditional usage

### DIFF
--- a/external/portaudio/pa_jack.c
+++ b/external/portaudio/pa_jack.c
@@ -1,4 +1,4 @@
-#ifdef UNIX
+#if defined (UNIX) && defined (JACK)
 /*
  * $Id: pa_jack.c 1912 2013-11-15 12:27:07Z gineera $
  * PortAudio Portable Real-Time Audio Library


### PR DESCRIPTION
`external/portaudio/READ_ME.TXT` says:

> Around pa_jack.c, do
> #if defined (UNIX) && defined (JACK)
> ...
> #endif

but there is only a `#ifdef UNIX` so that jack headers are required even if a non-jack build was chosen and the final binary doesn’t depend on jack.

This PR just adds the forgotten condition which also seems to be the cause for #1062.