### PR TITLE
Fix segfault due to invalid access Sound_getNearestLevelCrossing

### DIFF
--- a/dwtools/Sound_extensions.cpp
+++ b/dwtools/Sound_extensions.cpp
@@ -1079,9 +1079,10 @@ double Sound_getNearestLevelCrossing (Sound me, integer channel, double position
 	if (searchDirection == kSoundSearchDirection::LEFT ||
 		searchDirection == kSoundSearchDirection::NEAREST) {
 		for (ileft = leftSample - 1; ileft >= 1; ileft --)
-			if ((amplitude [ileft] >= level) != (amplitude [ileft + 1] >= level))
+			if ((amplitude [ileft] >= level) != (amplitude [ileft + 1] >= level)) {
+				leftCrossing = interpolate (me, ileft, channel, level);
 				break;
-		leftCrossing = interpolate (me, ileft, channel, level);
+			}
 		if (searchDirection == kSoundSearchDirection::LEFT)
 			return ileft < 1 ? undefined: leftCrossing;
 	}
@@ -1091,9 +1092,10 @@ double Sound_getNearestLevelCrossing (Sound me, integer channel, double position
 	if (searchDirection == kSoundSearchDirection::RIGHT ||
 		searchDirection == kSoundSearchDirection::NEAREST) {
 		for (iright = rightSample + 1; iright <= my nx; iright ++)
-			if ((amplitude [iright] >= level) != (amplitude [iright - 1] >= level))
+			if ((amplitude [iright] >= level) != (amplitude [iright - 1] >= level)) {
+				rightCrossing = interpolate (me, iright - 1, channel, level);
 				break;
-		rightCrossing = interpolate (me, iright - 1, channel, level);
+			}
 		if (searchDirection == kSoundSearchDirection::RIGHT)
 			return iright > my nx ? undefined : rightCrossing;
 	}


### PR DESCRIPTION
Line https://github.com/praat/praat/blob/51f96cd66e4c294d5758f085076b8cb12f04cf5e/dwtools/Sound_extensions.cpp#L1084 is not guarded against negative `ileft` values.

This is tested in `dwtest/test_Sound_levelCrossings.praat`, yet somehow this value is not negative enough to always trigger a segfault:
https://github.com/praat/praat/blob/51f96cd66e4c294d5758f085076b8cb12f04cf5e/dwtest/test_Sound_levelCrossings.praat#L14

I would guess it is bad luck that this test most of the time does not trigger a segfault, probably because the accessed memory is still allocated by Praat and the invalid memory access is not detected by Praat - it's called *undefined* behavior for a reason?
At any rate, changing that to a much smaller position (e.g., `time = Get nearest level crossing: 1, -100, level, "left"`) does trigger the bug, both in the script as well as interactively.

This PR fixes the error, following control flow of `Sound_getNearestZeroCrossing` more closely:
https://github.com/praat/praat/blob/51f96cd66e4c294d5758f085076b8cb12f04cf5e/fon/Sound.cpp#L883
