### PR TITLE
Fix #199

### DIFF
--- a/sys/praat.cpp
+++ b/sys/praat.cpp
@@ -1078,6 +1078,7 @@ void praat_init (conststring32 title, int argc, char **argv)
 	while (praatP.argumentNumber < argc && argv [praatP.argumentNumber] [0] == '-') {
 		if (strequ (argv [praatP.argumentNumber], "-")) {
 			praatP.hasCommandLineInput = true;
+			praatP.argumentNumber += 1;
 		} else if (strequ (argv [praatP.argumentNumber], "--open")) {
 			foundTheOpenOption = true;
 			praatP.argumentNumber += 1;


### PR DESCRIPTION
When trying to start a text-only Praat shell from the command line, Praat currently gets stuck in an infinite loop while parsing the command line arguments. This patch fixes it, but maybe there was another reason why `praatP.argumentNumber` wasn't being incremented in the branch matching the `-` argument? If so, a more complicated fix might be necessary.