### PR TITLE
Compile against Gtk3

### DIFF
--- a/sys/GuiButton.cpp
+++ b/sys/GuiButton.cpp
@@ -126,13 +126,22 @@ GuiButton GuiButton_create (GuiForm parent, int left, int right, int top, int bo
 		_GuiObject_setUserData (my d_widget, me.get());
 		my v_positionInForm (my d_widget, left, right, top, bottom, parent);
 		if (flags & GuiButton_DEFAULT || flags & GuiButton_ATTRACTIVE) {
-			GTK_WIDGET_SET_FLAGS (my d_widget, GTK_CAN_DEFAULT);
+			#if ALLOW_GDK_DRAWING
+				GTK_WIDGET_SET_FLAGS (my d_widget, GTK_CAN_DEFAULT);
+			#else
+				gtk_widget_set_can_default (GTK_WIDGET (my d_widget), TRUE);
+			#endif
 			GtkWidget *shell = gtk_widget_get_toplevel (GTK_WIDGET (my d_widget));
 			Melder_assert (shell);
 			gtk_window_set_default (GTK_WINDOW (shell), GTK_WIDGET (my d_widget));
 		} else if (1) {
-			gtk_button_set_focus_on_click (GTK_BUTTON (my d_widget), false);
-			GTK_WIDGET_UNSET_FLAGS (my d_widget, GTK_CAN_DEFAULT);
+			#if ALLOW_GDK_DRAWING
+				gtk_button_set_focus_on_click (GTK_BUTTON (my d_widget), false);
+				GTK_WIDGET_UNSET_FLAGS (my d_widget, GTK_CAN_DEFAULT);
+			#else
+			        gtk_widget_set_focus_on_click (GTK_WIDGET (my d_widget), false);
+				gtk_widget_set_can_default (GTK_WIDGET (my d_widget), FALSE);
+			#endif
 		}
 		g_signal_connect (G_OBJECT (my d_widget), "destroy", G_CALLBACK (_GuiGtkButton_destroyCallback), me.get());
 		g_signal_connect (GTK_BUTTON (my d_widget), "clicked", G_CALLBACK (_GuiGtkButton_activateCallback), me.get());

--- a/sys/GuiMenu.cpp
+++ b/sys/GuiMenu.cpp
@@ -542,7 +542,12 @@ GuiMenu GuiMenu_createInForm (GuiForm form, int left, int right, int top, int bo
 			gtk_widget_set_sensitive (GTK_WIDGET (my d_widget), false);
 
 		g_signal_connect_object (G_OBJECT (my d_cascadeButton -> d_widget), "event",
-			GTK_SIGNAL_FUNC (button_press), G_OBJECT (my d_widget), G_CONNECT_SWAPPED);
+			#if ALLOW_GDK_DRAWING
+				GTK_SIGNAL_FUNC (button_press),
+			#else
+				G_CALLBACK (button_press),
+			#endif
+			G_OBJECT (my d_widget), G_CONNECT_SWAPPED);
 		g_object_set_data (G_OBJECT (my d_widget), "button", my d_cascadeButton -> d_widget);
 		gtk_menu_attach_to_widget (GTK_MENU (my d_widget), GTK_WIDGET (my d_cascadeButton -> d_widget), nullptr);
 		gtk_button_set_alignment (GTK_BUTTON (my d_cascadeButton -> d_widget), 0.0f, 0.5f);

--- a/sys/GuiMenuItem.cpp
+++ b/sys/GuiMenuItem.cpp
@@ -223,9 +223,15 @@ GuiMenuItem GuiMenu_addItem (GuiMenu menu, conststring32 title, uint32 flags,
 		
 		#if gtk
 			static const guint acceleratorKeys [] = { 0,
+			#if ALLOW_GDK_DRAWING
 				GDK_Left, GDK_Right, GDK_Up, GDK_Down, GDK_Pause, GDK_Delete, GDK_Insert, GDK_BackSpace,
 				GDK_Tab, GDK_Return, GDK_Home, GDK_End, GDK_Return, GDK_Page_Up, GDK_Page_Down, GDK_Escape,
 				GDK_F1, GDK_F2, GDK_F3, GDK_F4, GDK_F5, GDK_F6, GDK_F7, GDK_F8, GDK_F9, GDK_F10, GDK_F11, GDK_F12,
+			#else
+				GDK_KEY_Left, GDK_KEY_Right, GDK_KEY_Up, GDK_KEY_Down, GDK_KEY_Pause, GDK_KEY_Delete, GDK_KEY_Insert, GDK_KEY_BackSpace,
+				GDK_KEY_Tab, GDK_KEY_Return, GDK_KEY_Home, GDK_KEY_End, GDK_KEY_Return, GDK_KEY_Page_Up, GDK_KEY_Page_Down, GDK_KEY_Escape,
+				GDK_KEY_F1, GDK_KEY_F2, GDK_KEY_F3, GDK_KEY_F4, GDK_KEY_F5, GDK_KEY_F6, GDK_KEY_F7, GDK_KEY_F8, GDK_KEY_F9, GDK_KEY_F10, GDK_KEY_F11, GDK_KEY_F12,
+ 			#endif
 				0, 0, 0 };
 			GdkModifierType modifiers = (GdkModifierType) 0;
 			if (flags & GuiMenu_COMMAND) modifiers = (GdkModifierType) (modifiers | GDK_CONTROL_MASK);

--- a/sys/GuiOptionMenu.cpp
+++ b/sys/GuiOptionMenu.cpp
@@ -67,7 +67,11 @@ void GuiOptionMenu_init (GuiOptionMenu me, GuiForm parent, int left, int right, 
 	my d_shell = parent -> d_shell;
 	my d_parent = parent;
 	#if gtk
-		my d_widget = gtk_combo_box_new_text ();
+		#if ALLOW_GDK_DRAWING
+			my d_widget = gtk_combo_box_new_text ();
+		#else
+			my d_widget = gtk_combo_box_text_new ();
+		#endif
 		gtk_widget_set_size_request (GTK_WIDGET (my d_widget), right - left, bottom - top + 8);
 		gtk_fixed_put (GTK_FIXED (parent -> d_widget), GTK_WIDGET (my d_widget), left, top - 6);
 		gtk_combo_box_set_focus_on_click (GTK_COMBO_BOX (my d_widget), false);

--- a/sys/GuiOptionMenu.cpp
+++ b/sys/GuiOptionMenu.cpp
@@ -142,7 +142,11 @@ GuiOptionMenu GuiOptionMenu_createShown (GuiForm parent, int left, int right, in
 
 void GuiOptionMenu_addOption (GuiOptionMenu me, conststring32 text) {
 	#if gtk
-		gtk_combo_box_append_text (GTK_COMBO_BOX (my d_widget), Melder_peek32to8 (text));
+		#if ALLOW_GDK_DRAWING
+			gtk_combo_box_append_text (GTK_COMBO_BOX (my d_widget), Melder_peek32to8 (text));
+		#else
+			gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (my d_widget), Melder_peek32to8 (text));
+		#endif
 	#elif motif
 		autoGuiMenuItem menuItem = Thing_new (GuiMenuItem);
 		menuItem -> d_widget = XtVaCreateManagedWidget (Melder_peek32to8 (text), xmToggleButtonWidgetClass, my d_widget, nullptr);

--- a/sys/GuiOptionMenu.cpp
+++ b/sys/GuiOptionMenu.cpp
@@ -75,7 +75,11 @@ void GuiOptionMenu_init (GuiOptionMenu me, GuiForm parent, int left, int right, 
 		gtk_widget_set_size_request (GTK_WIDGET (my d_widget), right - left, bottom - top + 8);
 		gtk_fixed_put (GTK_FIXED (parent -> d_widget), GTK_WIDGET (my d_widget), left, top - 6);
 		gtk_combo_box_set_focus_on_click (GTK_COMBO_BOX (my d_widget), false);
-		GTK_WIDGET_UNSET_FLAGS (my d_widget, GTK_CAN_DEFAULT);
+		#if ALLOW_GDK_DRAWING
+			GTK_WIDGET_UNSET_FLAGS (my d_widget, GTK_CAN_DEFAULT);
+		#else
+			gtk_widget_set_can_default (GTK_WIDGET (my d_widget), FALSE);
+		#endif
 	#elif motif
 		my d_xmMenuBar = XmCreateMenuBar (parent -> d_widget, "UiOptionMenu", nullptr, 0);
 		XtVaSetValues (my d_xmMenuBar, XmNx, left - 4, XmNy, top - 4,

--- a/sys/sendpraat.c
+++ b/sys/sendpraat.c
@@ -228,6 +228,7 @@ char *sendpraat (void *display, const char *programName, long timeOut, const cha
 			/*
 			 * Notify main window.
 			 */
+#if ALLOW_GDK_DRAWING
 			GdkEventClient gevent;
 #if !GLIB_CHECK_VERSION(2,35,0)
 			g_type_init ();
@@ -253,6 +254,7 @@ char *sendpraat (void *display, const char *programName, long timeOut, const cha
 				return errorMessage;
 			}
 			if (! displaySupplied) gdk_display_close (display);
+#endif
 		}
 		/*
 		 * Wait for the running program to notify us of completion,


### PR DESCRIPTION
This series of commits fix compilation errors against GTK3.

I am not sure about commit d9b0caf, in which I just skipped the code involving GdkEventClient when compiling againts GTK3.

Finally, the praat program builds fine and it launches correctly, but nothing appears in the edition windows. 