### PR TITLE
Freebsd port

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,15 @@ and type one of the four following commands:
 
     # on Raspberry Pi command line
     cp makefiles/makefile.defs.linux.rpi ./makefile.defs
+    
+    # On FreeBSD command line
+    cp makefiles/makefile.defs.freebsd.alsa ./makefile.defs
 
 To build the Praat executable, type `make` or `make -j12`.
 If your Unix isn’t Linux, you may have to edit the library names in the makefile
 (you may need pthread, gtk-3, gdk-3, atk-1.0, pangoft2-1.0, gdk_pixbuf-2.0, m, pangocairo-1.0,
-cairo-gobject, cairo, gio-2.0, pango-1.0, freetype, fontconfig, gobject-2.0, gmodule-2.0, gthread-2.0, rt, glib-2.0, asound, jack).
+cairo-gobject, cairo, gio-2.0, pango-1.0, freetype, fontconfig, gobject-2.0, gmodule-2.0, 
+gthread-2.0, rt, glib-2.0, asound, jack).
 
 When compiling Praat on an external supercomputer or so, you will not have sound.
 If you do have `libgtk-3-dev` (and its dependencies), do
@@ -209,8 +213,8 @@ If you do have `libgtk-3-dev` (and its dependencies), do
 
 Then type `make` or `make -j12` to build the program. If your Unix isn’t Linux,
 you may have to edit the library names in the makefile (you may need pthread, gtk-3, gdk-3, atk-1.0,
-pangoft2-1.0, gdk_pixbuf-2.0, m, pangocairo-1.0, cairo-gobject, cairo, gio-2.0, pango-1.0, freetype, fontconfig, gobject-2.0,
-gmodule-2.0, gthread-2.0, rt, glib-2.0).
+pangoft2-1.0, gdk_pixbuf-2.0, m, pangocairo-1.0, cairo-gobject, cairo, gio-2.0, pango-1.0, 
+freetype, fontconfig, gobject-2.0, gmodule-2.0, gthread-2.0, rt, glib-2.0).
 
 When compiling Praat for use as a server for commands from your web pages, you may not need sound or a GUI. Do
 

--- a/makefiles/makefile.defs.freebsd.alsa
+++ b/makefiles/makefile.defs.freebsd.alsa
@@ -24,9 +24,16 @@ AUDIO=-DALSA
 # but clang does not.
 COMMONFLAGS = -DUNIX -Dlinux $(AUDIO) -D_FILE_OFFSET_BITS=64 `pkg-config --cflags gtk+-3.0` -Wreturn-type -Wunused -Wunused-parameter -Wuninitialized -O1 -g1 -pthread $(CPPFLAGS)
 
-CFLAGS = -DHAVE_SYS_SOUNDCARD_H -std=gnu99 $(COMMONFLAGS) -Werror=implicit
+CFLAGS = -std=gnu99 $(COMMONFLAGS) \
+	-DHAVE_SYS_SOUNDCARD_H \
+	-Werror=implicit
 
-CXXFLAGS = -std=c++17 $(COMMONFLAGS) -Wshadow -DHAVE_SYS_SOUNDCARD_H -Werror=implicit -I$(LOCALBASE)/include -I$(LOCALBASE)/include/unicode
+CXXFLAGS = -std=c++17 $(COMMONFLAGS) \
+	-DHAVE_SYS_SOUNDCARD_H \
+	-Wshadow \
+	-Werror=implicit \
+	-Werror=return-type \
+	-I$(LOCALBASE)/include -I$(LOCALBASE)/include/unicode
 
 EXECUTABLE = praat
 

--- a/makefiles/makefile.defs.freebsd.alsa
+++ b/makefiles/makefile.defs.freebsd.alsa
@@ -41,6 +41,8 @@ LIBS = `pkg-config --libs gtk+-3.0` -L$(LOCALBASE)/lib -lasound -lm -lpthread -l
 
 AR = ar
 RANLIB = ls
+RM = rm -f
+
 ICON =
 MAIN_ICON =
 

--- a/makefiles/makefile.defs.freebsd.alsa
+++ b/makefiles/makefile.defs.freebsd.alsa
@@ -1,0 +1,39 @@
+# $FreeBSD: head/audio/praat/files/makefile.defs.freebsd.alsa 532890 2020-04-24 19:22:03Z jwb $
+# File: makefile.defs.freebsd.alsa
+
+# System: FreeBSD
+# Paul Boersma, 23 March 2020
+# J Bacon, 24 April 2020
+# Adriaan de Groot, 30 September 2020
+
+# Where external / third-party software is installed; needs to be
+# added to include and linker paths. (In the FreeBSD ports system,
+# this is already set so nothing is overridden)
+LOCALBASE ?= /usr/local
+
+# FreeBSD defaults to clang, not gcc
+CC ?= cc
+CXX ?= c++
+LINK ?= $(CXX)
+
+# -DALSA or -DJACK: Use ALSA or Jack audio in pa_unix_hostapis.c
+AUDIO=-DALSA
+
+# FreeBSD pretends to be Linux for most of the code; add CPPFLAGS
+# explicitly because GNU make / gcc uses those preprocessor flags,
+# but clang does not.
+COMMONFLAGS = -DUNIX -Dlinux $(AUDIO) -D_FILE_OFFSET_BITS=64 `pkg-config --cflags gtk+-3.0` -Wreturn-type -Wunused -Wunused-parameter -Wuninitialized -O1 -g1 -pthread $(CPPFLAGS)
+
+CFLAGS = -DHAVE_SYS_SOUNDCARD_H -std=gnu99 $(COMMONFLAGS) -Werror=implicit
+
+CXXFLAGS = -std=c++17 $(COMMONFLAGS) -Wshadow -DHAVE_SYS_SOUNDCARD_H -Werror=implicit -I$(LOCALBASE)/include -I$(LOCALBASE)/include/unicode
+
+EXECUTABLE = praat
+
+LIBS = `pkg-config --libs gtk+-3.0` -L$(LOCALBASE)/lib -lasound -lm -lpthread -ltinfow -lX11
+
+AR = ar
+RANLIB = ls
+ICON =
+MAIN_ICON =
+


### PR DESCRIPTION
This PR tries to add downstream packaging fixes -- in this case, makefile settings -- to upstream so that we can simplify packaging. That makes it slightly more likely that changes like GTK3 will "automatically" end up in FreeBSD packaging. I appreciate that upstream probably doesn't have facilities to actually test these builds, though.

While here, add some minor documentation for FreeBSD builds, as if it is Linux (it is UNIX-like, after all).