### PR TITLE
Makefiles: split external build from Praat-itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,27 +12,7 @@ include makefile.defs
 .PHONY: all clean install
 
 # Makes the Praat executable in the source directory.
-all:
-	$(MAKE) -C external/clapack
-	$(MAKE) -C external/gsl
-	$(MAKE) -C external/glpk
-	$(MAKE) -C external/mp3
-	$(MAKE) -C external/flac
-	$(MAKE) -C external/portaudio
-	$(MAKE) -C external/espeak
-	$(MAKE) -C kar
-	$(MAKE) -C melder
-	$(MAKE) -C sys
-	$(MAKE) -C dwsys
-	$(MAKE) -C stat
-	$(MAKE) -C fon
-	$(MAKE) -C dwtools
-	$(MAKE) -C LPC
-	$(MAKE) -C EEG
-	$(MAKE) -C gram
-	$(MAKE) -C FFNet
-	$(MAKE) -C artsynth
-	$(MAKE) -C main main_Praat.o $(ICON)
+all: all-external all-self
 	$(LINK) -o $(EXECUTABLE) main/main_Praat.o $(MAIN_ICON) fon/libfon.a \
 		artsynth/libartsynth.a FFNet/libFFNet.a \
 		gram/libgram.a EEG/libEEG.a \
@@ -47,7 +27,34 @@ all:
 		external/gsl/libgsl.a \
 		$(LIBS)
 
-clean:
+all-external:
+	$(MAKE) -C external/clapack
+	$(MAKE) -C external/gsl
+	$(MAKE) -C external/glpk
+	$(MAKE) -C external/mp3
+	$(MAKE) -C external/flac
+	$(MAKE) -C external/portaudio
+	$(MAKE) -C external/espeak
+
+all-self:
+	$(MAKE) -C kar
+	$(MAKE) -C melder
+	$(MAKE) -C sys
+	$(MAKE) -C dwsys
+	$(MAKE) -C stat
+	$(MAKE) -C fon
+	$(MAKE) -C dwtools
+	$(MAKE) -C LPC
+	$(MAKE) -C EEG
+	$(MAKE) -C gram
+	$(MAKE) -C FFNet
+	$(MAKE) -C artsynth
+	$(MAKE) -C main main_Praat.o $(ICON)
+
+clean: clean-external clean-self
+	$(RM) praat
+
+clean-external:
 	$(MAKE) -C external/clapack clean
 	$(MAKE) -C external/gsl clean
 	$(MAKE) -C external/glpk clean
@@ -55,6 +62,8 @@ clean:
 	$(MAKE) -C external/flac clean
 	$(MAKE) -C external/portaudio clean
 	$(MAKE) -C external/espeak clean
+
+clean-self:
 	$(MAKE) -C kar clean
 	$(MAKE) -C melder clean
 	$(MAKE) -C sys clean
@@ -68,7 +77,6 @@ clean:
 	$(MAKE) -C FFNet clean
 	$(MAKE) -C artsynth clean
 	$(MAKE) -C main clean
-	$(RM) praat
 
 install:
 	$(INSTALL)


### PR DESCRIPTION
This introduces intermediate targets all-external and clean-external
that deal with the bundled external packages, and also all-self and
clean-self that deal with the Praat sources themselves.

This is inspired by #1238, and makes it slightly easier to
build externals while ignoring warnings, and then building
Praat itself while paying attention to warnings.