### PR TITLE
Link against the OPUS library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ all: all-external all-self
 		external/clapack/libclapack.a \
 		external/gsl/libgsl.a \
 		external/vorbis/libvorbis.a \
-		$(LIBS)
-		#external/opusfile/libopusfile.a \
+		$(LIBS) \
+		external/opusfile/libopusfile.a
 
 all-external:
 	$(MAKE) -C external/clapack


### PR DESCRIPTION
The tarball for version 6.1.38 does not work out of the box.  It yields the following compilation error:

```
g++ -o praat main/main_Praat.o  fon/libfon.a \
        artsynth/libartsynth.a FFNet/libFFNet.a \
        gram/libgram.a EEG/libEEG.a \
        LPC/libLPC.a dwtools/libdwtools.a \
        fon/libfon.a stat/libstat.a dwsys/libdwsys.a \
        sys/libsys.a melder/libmelder.a kar/libkar.a \
        external/espeak/libespeak.a \
        external/portaudio/libportaudio.a \
        external/flac/libflac.a external/mp3/libmp3.a \
        external/glpk/libglpk.a \
        external/clapack/libclapack.a \
        external/gsl/libgsl.a \
        external/vorbis/libvorbis.a \
        `"pkg-config" --libs gtk+-3.0` -lm -lpulse -lasound -lpthread -L /usr/lib/x86_64-linux-gnu -lX11 -Wl,-z,relro -Wl,-z,now
/usr/bin/ld: dwtools/libdwtools.a(Sound_extensions.o): in function `Sound_readFromOggOpusFile(structMelderFile*)':
./Sound_extensions.cpp:710: undefined reference to `op_open_file(char const*, int*)'
/usr/bin/ld: ./Sound_extensions.cpp:731: undefined reference to `op_head(OggOpusFile const*, int)'
/usr/bin/ld: ./Sound_extensions.cpp:737: undefined reference to `op_pcm_total(OggOpusFile const*, int)'
/usr/bin/ld: ./Sound_extensions.cpp:749: undefined reference to `op_read_float(OggOpusFile*, float*, int, int*)'
/usr/bin/ld: ./Sound_extensions.cpp:762: undefined reference to `op_head(OggOpusFile const*, int)'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:17: all] Error 1
```

The present commit fixes the problem.