### PR TITLE
Unreached, but let's add a return value to avoid warnings

### DIFF
--- a/fon/PitchTierArea.h
+++ b/fon/PitchTierArea.h
@@ -33,6 +33,7 @@ Thing_define (PitchTierArea, RealTierArea) {
 			return U" st";
 		else
 			Melder_fatal (U"PitchTierArea::v_rightTickUnits: Unknown pitch units: ", (int) our p_units);
+		return nullptr;
 	}
 	double v_defaultYmin ()
 		override { return 50.0; }


### PR DESCRIPTION
There are various things we could do here: `__builtin_unreachable();` is one, but that only works for gcc and clang. Some projects `#define` an UNREACHABLE to something suitable for the compiler .. that might be one to add to a common header file. Another option is to mark `Melder_fatal()` with `[[noreturn]]`. that is available since C++11 but I don't know the MSVC / Mac status for that. The third is just to return something bogus, which is what this PR adds.