### PR TITLE
Fix tests by explicitly copying

### DIFF
--- a/fon/Praat_tests.cpp
+++ b/fon/Praat_tests.cpp
@@ -742,7 +742,7 @@ public:
 };
 
 static Vec copy (Vec x) {
-	return x;
+	return Vec(x);
 }
 
 /*static void tryVec () {


### PR DESCRIPTION
- The Vec class is wrestling with copy-semantics and copy-
  assignment, but in doing so, the implicit copy constructor
  isn't available in this test-function.

FIXES #1933 