### PR TITLE
Fix build with -Werror

### DIFF
--- a/LPC/PowerCepstrum.cpp
+++ b/LPC/PowerCepstrum.cpp
@@ -397,7 +397,7 @@ static autoMAT PowerCepstrum_getRhamonicsPower (PowerCepstrum me, double pitchFl
 }
 
 double PowerCepstrum_nearestPeak (PowerCepstrum me, double quefrency) {
-	
+	return 0.0;
 }
 
 autoTable PowerCepstrum_to_Table_rhamonics (PowerCepstrum me, double pitchFloor, double pitchCeiling, double f0fractionalWidth) {


### PR DESCRIPTION
- Although this function isn't called, building praat with
  picky flags -- such as -Werror -- fails because the function
  doesn't return anything.