### PR TITLE
Add desktop file for using Praat as audio viewer

### DIFF
--- a/main/praat-file.desktop
+++ b/main/praat-file.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Version=1.0
+Name=Praat Speech Analyzer
+Name[en_GB]=Praat Speech Analyser
+GenericName=Speech Analyzer
+GenericName[en_GB]=Speech Analyser
+Comment=Analyze, synthesize and manipulate speech
+Comment[en_GB]=Analyse, synthesise and manipulate speech
+Type=Application
+Exec=praat --open %F
+Icon=praat-file
+Categories=Education;Science;Viewer
+MimeType=audio/flac;audio/mpeg;audio/x-aiff;audio/x-wav;
+Keywords=audio;sound;speech;phonetics

--- a/main/praat-file.svg
+++ b/main/praat-file.svg
@@ -1,0 +1,482 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 380 379"
+   version="1.1"
+   id="svg51"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs22">
+    <style
+       id="style2">.cls-1{isolation:isolate;}.cls-2{opacity:0.35;}.cls-2,.cls-4,.cls-6{mix-blend-mode:multiply;}.cls-3{fill:url(#linear-gradient);}.cls-4{opacity:0.25;}.cls-5{fill:#f7f1f0;}.cls-6{opacity:0.15;}.cls-7{fill:url(#linear-gradient-2);}</style>
+    <linearGradient
+       id="linear-gradient"
+       x1="130.08"
+       y1="553.75"
+       x2="472.3"
+       y2="211.53"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#b13d5c"
+         id="stop4" />
+      <stop
+         offset="0.18"
+         stop-color="#c34d6a"
+         id="stop6" />
+      <stop
+         offset="0.49"
+         stop-color="#dc637c"
+         id="stop8" />
+      <stop
+         offset="0.77"
+         stop-color="#ec7088"
+         id="stop10" />
+      <stop
+         offset="1"
+         stop-color="#f1758c"
+         id="stop12" />
+    </linearGradient>
+    <linearGradient
+       id="linear-gradient-2"
+       x1="259.03"
+       y1="258.2"
+       x2="259.03"
+       y2="258.2"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#231f20"
+         stop-opacity="0.87"
+         id="stop15" />
+      <stop
+         offset="0.4"
+         stop-color="#191617"
+         stop-opacity="0.62"
+         id="stop17" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop19" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3406"
+       x1="302.85999"
+       x2="302.85999"
+       y1="366.64999"
+       y2="609.51001"
+       gradientTransform="matrix(0.067325,0,0,0.0147,-0.34114,37.04)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop5050"
+         style="stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         offset=".5" />
+      <stop
+         id="stop5052"
+         style="stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient3403"
+       cx="605.71002"
+       cy="486.64999"
+       r="117.14"
+       gradientTransform="matrix(-0.02304,0,0,0.0147,21.623,37.04)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient3400"
+       cx="605.71002"
+       cy="486.64999"
+       r="117.14"
+       gradientTransform="matrix(0.02304,0,0,0.0147,26.361,37.04)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       id="linearGradient3395"
+       x1="25.132"
+       x2="25.132"
+       y1="0.98521"
+       y2="47.013"
+       gradientTransform="matrix(1,0,0,0.95617,-1.0065e-7,-1.9149)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3397"
+       x1="-51.785999"
+       x2="-51.785999"
+       y1="50.785999"
+       y2="2.9061999"
+       gradientTransform="matrix(0.8075,0,0,0.89483,59.41,-2.9806)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3106"
+         style="stop-color:#aaa"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#c8c8c8"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient3392"
+       cx="102"
+       cy="112.3"
+       r="139.56"
+       gradientTransform="matrix(0.3617,0,0,-0.39078,0.85106,47.517)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop41"
+         style="stop-color:#b7b8b9"
+         offset="0" />
+      <stop
+         id="stop47"
+         style="stop-color:#ececec"
+         offset=".18851" />
+      <stop
+         id="stop49"
+         style="stop-color:#fafafa;stop-opacity:0"
+         offset=".25718" />
+      <stop
+         id="stop51"
+         style="stop-color:#fff;stop-opacity:0"
+         offset=".30111" />
+      <stop
+         id="stop53"
+         style="stop-color:#fafafa;stop-opacity:0"
+         offset=".5313" />
+      <stop
+         id="stop55"
+         style="stop-color:#ebecec;stop-opacity:0"
+         offset=".8449" />
+      <stop
+         id="stop57"
+         style="stop-color:#e1e2e3;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3389"
+       x1="24"
+       x2="24"
+       y1="2"
+       y2="46.016998"
+       gradientTransform="matrix(1,0,0,0.97778,0,-0.96667)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3213"
+         style="stop-color:#fff"
+         offset="0" />
+      <stop
+         id="stop3215"
+         style="stop-color:#fff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient3386"
+       cx="22.902"
+       cy="45.867001"
+       r="7.9059"
+       gradientTransform="matrix(0.69765,0,0,0.29961,12.507,15.89)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3197"
+         offset="0" />
+      <stop
+         id="stop3199"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient3383"
+       cx="22.902"
+       cy="45.867001"
+       r="7.9059"
+       gradientTransform="matrix(0.75875,0,0,0.32584,-0.80598,16.479)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3203"
+         offset="0" />
+      <stop
+         id="stop3205"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient3379"
+       cx="17.059"
+       cy="41.058998"
+       r="5.7385001"
+       fx="14.638"
+       fy="38.174999"
+       gradientTransform="matrix(0.66498,0,-0.10886,0.63739,9.9382,2.2626)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3877"
+         style="stop-color:#aaa"
+         offset="0" />
+      <stop
+         id="stop3879"
+         style="stop-color:#4d4d4d"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient3376"
+       cx="17.059"
+       cy="41.058998"
+       r="5.7385001"
+       fx="14.109"
+       fy="38.980999"
+       gradientTransform="matrix(0.66333,0,-0.10859,0.6358,21.997,0.49746)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3871"
+         style="stop-color:#aaa"
+         offset="0" />
+      <stop
+         id="stop3873"
+         style="stop-color:#4d4d4d"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3373"
+       x1="28.739"
+       x2="25.4"
+       y1="144.12"
+       y2="119.86"
+       gradientTransform="matrix(0.22147,0,0,0.22311,14.032,-19.079)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3239"
+         style="stop-color:#fff"
+         offset="0" />
+      <stop
+         id="stop3241"
+         style="stop-color:#fff;stop-opacity:.37931"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3370"
+       x1="28.739"
+       x2="26.257"
+       y1="144.12"
+       y2="125.39"
+       gradientTransform="matrix(0.44563,0,0,0.22311,20.716,-20.657)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3245"
+         style="stop-color:#fff"
+         offset="0" />
+      <stop
+         id="stop3247"
+         style="stop-color:#fff;stop-opacity:.37931"
+         offset="1" />
+    </linearGradient>
+    <filter
+       id="filter3212"
+       x="-0.1484589"
+       y="-0.1643425"
+       width="1.2969178"
+       height="1.328685"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur3214"
+         stdDeviation="0.77391625" />
+    </filter>
+    <linearGradient
+       id="linearGradient3366"
+       x1="32.891998"
+       x2="36.358002"
+       y1="8.059"
+       y2="5.4565001"
+       gradientTransform="matrix(0.9977,0,0,1.0407,0.1638,-1.1058)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop8591"
+         style="stop-color:#fefefe"
+         offset="0" />
+      <stop
+         id="stop8593"
+         style="stop-color:#cbcbcb"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <title
+     id="title24">praat</title>
+  <g
+     class="cls-1"
+     id="g49">
+    <g
+       id="Layer_5"
+       data-name="Layer 5">
+      <image
+         class="cls-2"
+         width="380"
+         height="379"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAXwAAAF7CAYAAADR4jByAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4Xu2da3fbRrJFS7IVx3bsOMkkd/7/r5tJJk+/4tgy7wfyGAfFagAUXwC591q9QFmyxhORm6VT1Y2b1WoVAABw+Twe+wKAJXJzc3Mz9jUAx2A14yr6Zsb/NoAeEySePz/29QCHJgu19/G53wwQPsyGhtDHJH4zcgU4NSu7th6vH5xYwAgfTk4hdv/YhT0k8fx1rQVwSlbF+tx43HsDOIX8yfDhaAyIvSX1qSt//a1db+3j1v8+wKGoIhyJXeu+8djfAD7r5XJM8VPhw8EwwU8V+23xuJJ3lnj+HrcR8ShdK+kjfDg0LtAs+/vN+mTXT+nPtPxNYBVr7x9czggfHkSq3iuZt8Tckvmj9PhR8TiLPH/94+Lrs/QBjkEl+0+2PkbEP5trtfzNwKv/g1b8RDowmUYFX1XsLZlXIs+i1sePG5+r/jcep5W/ViB+ODS5wvfKXjL/x9aHtP7eXPV5yf8+1s/Xzzc3NweTPhU+NCmq+CHBVyKv5D1l3RWPq8pdH+e/m4WP6OHYeIWv6t6F74J/v7m+2zzWVX+exa/fGvYWPxU+9Bip4qvK3avwLOm7xmp9rvq7lcTzmlLhI304Fj5tk+OcXNlL+O8i4k1EvN1ctd5tVhZ/RMRq32of4UOWfFXFV4J3ufv6qlj5z+/sOkX8rQq/9caj5f8/AI7JypY3a1Xle4wjqb+JiNeb9WdE/GUfv41O/HoO38eeEQ/Cv1IGJF8JPlfvWeBP7FqtoTeBSvKtil0S96gm/1v1WJ+LQPhwfCRgNVxd+rnSV5zzNtZy/ysi/rD1NNZvAHo9vN/8PVX7D5Y+wr8yNqKXAFuVcq7iXdAu8q/t6mtI+q2KPss9V/VZ9pE+9jeq/HX6WoBjUDVuJf3P0WXxnudL+m9iLfyXEfEiIp5HxLPoXjN6Hfjz+T4i7h8ifYR/BRTVvJ48eiK1Ihqv4CXyp5vH+ZqF/7X9fZd9ruRd7rlSH5J46zeUvATCh2NRzeLnMU2J30c038da8lrPoxb+4+g/9z9urjtLH+FfKAORjUv+UfTlrieZSztLvlpZ9lnyrSp+itynSHzsCnAqVsXV5+p9ZPNprOWel7+O9Nqpip2IHaWP8C+MJPoqsvFK3qt3rZbUdxH9kORv7ZrF7o+jeOxXJ/8Zoodz06r6Ve3niLSKQ/VaypHO1vecKn2EfyFYNu/yrCR/F/0nWavKeGafc8G76HM173HNWAVfVe3+WB9Xj1tM+RqAU3ATnfT1vFzF+vm/iu0+WY5S/XXksq+kPrmRi/AXTiH6nMvnyMar+GfR5YbfRD9DzKIfimyqqGYononimh87iByWSPW81Z/dxrrSz0VZ9RtxVd17b8Cr/UEQ/gJpNGHzE0dC9hzeq3lJXuu5rSz61pRNbrhWko8YrtyH/gzgksjP8UfRf/366zi/nlzqvvu2J/yxKh/hL4iBfF7SrSp5F7yvSva5aeQ5YhXVtLL4KK4CsQN0ElfEoz/Lr229Xlz2n9Kq3gBKEP4CGMjns+hVkUvcLnSNfVUVvYvexynzr5iqPrLgfTnIHaCNvz5yweT4hE91IJsftby6ubm5aVX5CH/GNERfTdq46F3qL2J7zvcb+zpJ/mn0Y5sqR6wkH3bNjwFgGvm1dBf915LP8fvGLT9p88su3Oh+e9gC4c+Qhuir2Mazeclccn8Z3e69F9FV9VnyObapmkVU8QDHRZK+3Xz8OPqjnKrufZeuTtn0g9YGq3yEPyMso/eKWhW9qm/l8zmb90r+pS1V+5q6yU3YoakAqniA01FJP6LL7j9G/xwenbD5Ntbi/ye6PL+s8hH+TLCq3jv1im28mh+KbV6mj1XVZ9HnBmyrmhdIHuA0ZOlHdLHt81i/xv0MntfRHauseOc2GlU+wj8zKb6pRO/TNi3B65onbxT3SPStbB7JA8wHSV9OeBxdwfdNrF/v30bEq+iOVX4T3amayvK3QPhnohC9frDeiM3ZvH7QfnXRK6Mfquiral4geYB5oNeiF4GSvip9eeDP6M7Q/zu6LH9r9y3CPzFFTq9qWzn9k+jyeVXy30b3jq7HfpyqN2N9rLLanp1Fj+QB5otX+XfRRTuq9OUIvf6/iu7sfP2m8AWEf0IGcvrcjM2/tvn6Nvpjljm2GZu2EYgeYN5U0Y5++/eI1yNcRbePYjOxEyZ9hH8CJub0asZ6Rf/dZmXZ+9TNUGwzNG0DAPMnRztyRh7eyMLXa78Hwj8ijfimldN7Rv8qtmXvEY4y+qn5PKIHWDZeLEr6fnSKH4kiH9zEWkNfpnUQ/pFoxDe+aaoSfauqfxn9hqyL3t/NET3A5dLyiA9qyA3et/sCwj8wqaqv4hufvMk5fSX6PEufRU8+D3DZeAGXq3xFwj6VR6RzClJWX8U3mqipRK+VRe/d99yMpZoHuB48NXDpf2WrNZlHpHNIUoSTf+1Sg0Wzs1nyquzVlK1Ef2ffG9EDXBeStjtGv+mPyf4LCH9PigmcPH3jkzcu+u+jH+HkedonUef0t+v/ZUQPcIW4a+QbX3l4owfC34OiMat32zxPL9F/b0uyr6ZvfJa+yumRPcD14a9/7xH6yr64iVi7arVarRD+A2g0ZnNWr6r+u4j4IdaS1zVn9do8RU4PAEPkRMHlX8p+cyXDfwgDjdl8uNGr6CTvy7N63zxFTg8Au3LTWCUIfwcGGrMe4aiql+z/FX3Zq6r3piw5PQDsSlUUDjoD4U+giHCqufoX0WX1Erxk/310jVlFON6UJacHgKnkKn6yKxD+CI0Ip9WYrap65fVqzObtz8Q3AHAI3CGlRxD+AAMRjlf13pitqvpvo4twfCecRE98AwAnAeE32Mg+T+FoE1WrqpfsfQpH45aKcKjqAeAsIPxEI6/PEY5n9f+ypZFLzdbnxqzPyUYgegA4IQjfGMjrc2P2++gk/2NsT+HoaIRWYzYC2QPAiUH4G0byekU4Grf8MTrZq7L3xmzeRMUEDgCcHYQfW7L3kcs8W/9DrCWvpeasb6TKjVmqegCYBVcvfJO9mqme13uEI9n/FNvNWZ/CoTELALPkqoWfZK/KXnm9pnDUmM2VvZqzPoVDYxYAZsvVCr+QvSp7j3Bc9KrsNV8v2VdTOFT1ADA7rlL4DdmrOfttdFM4P9ly2fvIpd90gAgHAGbL1Ql/guw9q/+/zfXH6JqzOa/3kcsIRA8AM+WqhD8iezVnJXotNWgl+7xrlggHABbB1Qh/R9n/e3NVZf8qOtmT1wPAIrkK4U+QvWIcl/1PMSz7G1sAALPn4oX/ANn/O7rRS22octmT1wPAIrlo4e8p+6qyR/YAsFhu40JB9gAAfS5S+MgeAGCbixM+sgcAqLko4SN7AIA2FyN8ZA8AMMxFCB/ZAwCMs3jhI3sAgGksWvgTZK/bESJ7ALh6Fit8k/1tdPeg9fPs89k4yB4ArppFCj/JPlf2OuIY2QMAGIsU/gZFOarsn0dX2eeD0JA9AFw9ixP+prr3GOdJrG9I8jK62xL6mfY/BbIHAFiW8E32HuU8i/WJlq9iW/b5TlXIHgCulsUIfyS39/HL1j1okT0AXDWLEH4xkZObtLrpuIRPZg8AkFiE8DdUTVrl9l7dq7InxgEAMGYv/IEm7Yvoy/7HQPYAAE1mLfxGbv8stnfSKsZp3YMW2QPA1TNb4U9o0kr2quyV2b+I9ZvCk83fexTIHgBgvsLfMJTb/yu6Ru0Pmz97GZ3s7zZ/V5JH9gBw1cxS+CO5vUYwK9k/j/Ubg2R/G2vRI3sAuHpmJ/wJ5+T4CKY3aV32yu2RPQDAhtkJP/rz9q0RTGX2QxM5iB4AwJiV8FN1PxTlSPjfBk1aAIBJzEb4E6dyJHw/MiHLniYtAEDBLITfkL3fzCRHOd6k9YkccnsAgAazEP6G1gimqvtK9srtXfYAAFBwduGnEczW3atyk1ZRjpq05PYAACOcXfjRRTA6BTPfveoHW6+CzVUAAA/irMK37L66e5U3al32bK4CAHgAZxP+xA1WinG+i/ahaIgeAGACZxN+bG+wqqp7Lcnec3uXPdIHABjhLMKfsMEqy/5FEOUAAOzFyYU/Yebeha8RzG+iPicHAAAmcnLhb8hRzvPYru5d9k+j201LlAMA8ABOKnybuW81ar+LfpPWd9P6vD1RDgDAjpxU+NGfua9OwszVvXJ7pnIAAPbkZMJPM/ePY7tR68LXbtrWCCbSBwDYkZMJP/pjmL6j1scwv4u17LWbVtU9UQ4AwJ6cRPjFZI5X98rutXT3Kg5GAwA4IEcX/sAYplf33qTVBivOuAcAOCBHF/6GaketV/evYvhgNKIcAIA9OarwG2OYz6K/ySqPYHqU48ceAwDAHhxbptUYps7L8epeNyLn2GMAgCNxNOE3GrVPY7tRy7HHAAAn4GjCj/YmK5+7z9U9G6wAAI7EUYQ/UN17du+NWq/uXfhIHwDgQBxF+NHJWo3aPJmTZa9G7V1Q3QMAHIWDCz9V99pVq+pec/eKcnQzclX3XtkjfQCAA3Jw4W/w7D5X91q6qcnT6Bq1jGECAByJg8p1ZFfti+jGMV/E9v1pGcMEADgiBxX+Bt9oper+m+gq/JexHeXQqAUAODKHFr43az3OUX4v2XujljFMAIATcDDhDzRrFedoSfbaUUt1DwBwAg4m/Ohn99po5cLXSZhU9wAAZ+Agwm9U996s1Wqdl0N1DwBwZA4i/OiEnQ9JU7PWq3vuUQsAcAb2Fn5xr9qx6r46IA0AAI7M3sLf4Pl9HsXUZI7P3bOrFgDgxOwl/IGNVq1RzOqm5AAAcAL2Ev4G32jl5+aould+76OYnHcPAHBi9hX+WLNWUQ6jmAAAZ+bBwi/iHN9Z6w1bqnsAgBnwYOFvyPl93lnrkzlU9wAAZ2Qf4ec4R3e1ep6Wqns/EZPqHgDgxDxI+MXsvef3z2Nd2VPdAwDMiAcJP7oox2fvn0Zf+JJ9ld0DAMCJ2Vn4m+o+Yi1ub9YqztFUTp7MIc4BADgjOwt/gw5J84PSNI4p4euQNDZaAQDMgIcI38cxq+reD0mjWQsAMBN2En5j9j43a1Xds9EKAGBG7CT8DXn23uMcZff5zHuEDwBwZnYVfh7HfBL9Cl+y1ygmNzkBAJgJk4Vf3NXqLrrdtS3hU90DAMyEycLfkIWv+9Y+iy63941WCB8AYCbsIvyqYesbriR8jWJ6s5Y4BwDgzEwSftpslW9l+NRWHsWkugcAmAmThL/B4xwJ3yv8Ks5B9gAAM+GhwnfZ5+r+LohzAABmx1ThtzZceaTTGsUEAIAZMCr8YhwzxzmSfT4GmfweAGBGjAp/Qx7HzHFOvoUhm60AAGbGFOG3xjGJcwAAFsSg8NM4pp+fUzVsXfjEOQAAM2NqhZ/ze2/YajpHRykwjgkAMEOmCl8brnR+Tm7YqrpnHBMAYKaMCX8ov/dV3cYQAABmxJjwI7rq3it8l30+O4f8HgBghjSFn+bvhyr86mRMqnwAgJkxVuF7fu8TOrm6ZzoHAGDmDAnfK/zcsNXyZi3TOQAAM2ZKhV8dqaAqP1f3VPgAADOlFL7l90MV/lfRvrMV0gcAmBlTK3w1bLPwqzgH2QMAzJApGb7inLvoSz9vtiLOAQCYMWPCl8g90vFVjWMCAMAMaQlf4vaGbRa+xzlU9wAAM2esws+RTpZ9FecgfgCAGbIl/GJCR01bl77y/Hw6JrIHAJgpYxV+FelI9uT3AAALYijD94ZtntLJ45jIHgBg5gwJv6rwfSnOocIHAFgAlfA9j8/5vcc5+WYnAAAwY8YiHVXxLnzJvhrHRPwAADOlJ/x00/Ic6WTp39qiygcAmDmtSGeoaavqnvweAGBBjDVtXfaPbfn8PbIHAFgAYxV+K87xSAcAABbAmPBzpFM1bKnyAQAWQBZ+HsnMsmeHLQDAQhmr8PNYpsuekUwAgAUxNofv0s/rJi0AAJgxX4RfzODnKj/LPlf4AAAwY4Yy/Cx+j3Fo2AIALIyxscpK7kgeAGCBDAm/qvJd9kgfAGBBDE3ptGSP9AEAFsjQlE7O7j3DJ9YBAFgYVdN2SPbV/D0AACyAVqTjM/j50LRWvAMAADNmqML3Xbb5lEyqfACAheHC90asKvzHxarO0UH+AAAzp1XhK86Zeo4OAADMnCkZPufoAABcALcRMXSOTiV9fQ7RAwAsiFaGn6XvMU6e0gEAgAVQRToixzYIHgBgwQwJP2J7CgfpAwAslDHhOy56xA8AsDBawnehI3YAgAtglwofAAAWDMIHALgSED4AwJWA8AEArgSEDwBwJSB8AIArAeEDAFwJCB8A4EpA+AAAl8HKrnrcA+EDACyLLPRS7hUIHwBgmbj487UE4QMALJdVY5UgfACA5eBS/2xXX1n8X94AED4AwLJw2d+nVUp/tVqtIhA+AMBSyLFNln0l/R4IHwBgWXiMcx8RnyLi4+bq0t/K8xE+AMD88Txewpfs88oVPhk+AMBCceFn6evPyokdhA8AsAxyhl9V+WT4AAAXRM7wR6d0BMIHAFgOubpvSX+ruo9A+AAAS6EV6QxV91T4AAALxeOcnOGX+b02XUUgfACAJZCr9iz6+6BpCwCweFzcuWE7edNVBMIHAFgK1Tjmx9iWfrnpKgLhAwAsgapZq0gny54KHwDgApDQXfYf7WMiHQCAC8AbtnmHrVf5pewjED4AwBLIcY5n+EQ6AAAXgss+N2wH4xyfwY9A+AAAc6YaybyPTvYfI+KfqKW/BcIHAJg/1TimZK/HgyOZEQgfAGDutObv/7FFhQ8AcAF4fu/V/YdoV/gIHwBgYXg84xW+KnuX/qcYqO4jED4AwFwZk32OdHoVfp7QiUD4AABzp8rvP8R2dT+Y30cgfACAOZMbtt6sbcU5ZPgAAAukati67KnwAQAuAM/w8zhmFekMyj4C4QMAzJGhhu2H2Bb+aMM2AuEDAMwVj3M8v8/CnxTnRCB8AIC5ouZrlv3fm9Ws8KtvFoHwAQDmhk/aqFmrOOfv2Bb+6Dn4AuEDAMwTVff30a/u30cn/a1Ip5XfRyB8AIA5Us3eS/ZaXuGP5vcRCB8AYI5U+b0LX5FOtemqCcIHAJgPnt8rztFRCu9ju8KvzsFvgvABAOZF3l3rzdoqzpmU30cgfACAuTElzvk7doxzIhA+AMBcqMYxFee0GraT45wIhA8AMDdU3Xuc8z4i3sVAnFN+pwTCBwCYDz6O+Snq6j7P368i1gF+8f16IHwAgPNTxTnabKXq3iv8nfP7CIQPADAn8smYHudk4e8U50QgfACAuZB31yrOcdn7hqvJ45gC4QMAnJcc57jwJfu3m2uV30+SfQTCBwCYC9pslWfvc4W/0/k5DsIHADg/1ey9ZK/qvszvp8Y5EQgfAOCctKZzlN2/jQPFOREIHwDg3OTZ+3+iru73inMiED4AwLlx4VfV/ds4QJwTgfABAM6Fxzn5oLQc50j4D45zIhA+AMA5yaOYLvs3m5Xz+wfFOREIHwDgHExp1r6JfsO2d5zCrnFOBMIHADgX1Uar97GW/OvohO/5/U5n52QQPgDAecjVvWT/Juo4R7c8/Fx9sykgfACA01I1a3N1/zrqOGcVEZOOQq5A+AAAp6eV3b+JLs55E3uejplB+AAAp8MbtX6TE5e9hK9xzN6tDB9a3UcgfACAUzNW3bvw/WYnD27WCoQPAHAahkYxPbvP0zkaxXxws1YgfACA09HaaKXq/q/oGrZq1h4kzolA+AAAp6RV3Xuztjo7Zy/RC4QPAHB8WqOYObv36v5gzVqB8AEATsPQRiuPcnQUcu8oheL77QzCBwA4LrlR29po5cI/eHUfgfABAE5Bq7r3Ru1RRjEdhA8AcDzyRiufzJHstVz4BxvFdBA+AMBxqSZz1Kj9c7Nys3avY5BbIHwAgOOQq/s8hinZK9LxOOdgo5gOwgcAODwru/rtC99HN5Xjwj/aKKaD8AEAjoMqewnfG7W5uvedtQdv1gqEDwBwWPKZOblR+2dE/LFZatZqFPMo2b1A+AAAh8dl72OYf0Une1X4yu4l/KNU9xEIHwDgkFSbrNSoddlL+H6Tk6NW9xEIHwDg0OQxTJ2Xoyjn9821OhXzaNV9BMIHADgUrU1WXt3/vlmavT9ZdR+B8AEADkE1humnYXp179n9yar7CIQPAHAofAyzatQqylF2/y76kzmfj1ndRyB8AIB98THMXN17o9ajnLyr9qBn5rRA+AAADydHOZ+iH+Xk6j7vqj1Jdi8QPgDAfnij1qOcP6Nr0lbV/UllH4HwAQAeSp7K8cPRvLL/Lerq/suZOfkbHwuEDwCwO2NTOS57n7v36v4+TljdRyB8AICH0qruFeX8Fp3wvbo/2RhmBuEDAOzGWJQj2f+6ufoRCicdw8wgfACA6QxFOa9jHd247HN2f9IxzAzCBwDYjV2iHK/uddb9SSdzHIQPADANj3L8/rQe5fwa/eo+b7I6m+wjED4AwBSGNliNRTl5R+1ZZB+B8AEAxpCgFeOoutf9af+MLsapopyT76htgfABAMZp7aatpnJmF+UIhA8A0CaPYGoqJ+f2/9tcfeZ+NlGOQPgAADVTc3vJfmjm/uzVfQTCBwCoqHJ7l71ye8n+15hxlCMQPgBATY5yfN5estdqHZ8wiyhHIHwAgD5Vbl/N20v2s49yBMIHAOgYyu0r2beinPs4w1k5YyB8AIA1u+T2v8RwlDMr0QuEDwDQl70fnZA3V3llP9sNVi0QPgDAmnxOTiV7VfaKchYj+wiEDwCQm7T5BEyX/S+xsNzeQfgAcM0M7aTVccdZ9prKWURu7yB8ALhW8kROHr/8I9aC/yUifo5O+IvK7R2EDwDXSGsi5310xyb8L9aid9krylmc7CMQPgBcH0MTORq/zJW9j2AuKrd3ED4AXBNTxi+1sUq5/eLm7VsgfAC4FqbIXhM5Xtn70Qlb5+QspbqPQPgAcB2Myb5q0P4S2xM5yu3vY2Gyj0D4AHD5jGX2fq591aR9E11uv6gmbQbhA8AlM1bZK8b5JSL+u1k/x1r+vrnKJ3IW06TNIHwAuFTGZK8Y5+fYlv3iJ3IqED4AXCJTZa/K/j+ba5XbL3IipwLhA8ClsYvs/xOd7H+Ohe+kHQPhA8AlsY/sL2b8sgXCB4BL4aGyV4xTHXe8yPHLFggfAC6BfWTfOtv+omQfgfABYPkg+4k8HvsCAIAZM7apyg9Cu2rZRyB8AFguK1s64jhX9r9FN2d/1bKPQPgAsDxWdv0cw7LPc/aaxrk62UcgfABYFpXsdVvC6ojj/9q6atlHIHwAWA45r/fbEnpmr8peUc7Y7QmvQvYRCB8AlkGrOasbjnuD1k+91Nk4vqnqKmUfgfABYN54hJObs9UNx/3mJX63Kt9Be5Wyj0D4ADBfxpqzb2Mtct1w/Je0NImjWxO+j3UEdJWyj0D4ADBPqrz+U2w3Z3+P7ojjfFtCP89elf19XKnsIxA+AMyLKsLxSZx3sX3/Wb8tYc7r/Tz7izn18qEgfACYC60IR5M476I/iVPJXnn92+juVHVxp14+FIQPAHNgKMLx5myWvef1ukuVmrO6B61uXnLVso9A+ABwXqZEOJL977Et+19juznrkzh6A4lrl30EwgeA8zE0hSPZK8JRc/Z/tn6NLq/35qzn9Yu+B+2hQfgAcGpyVa+NVHnk0vN6yT5X9b6Zym82frWTOEMgfAA4JVVVfx9dVS/ZazOVIhxfv0c3cqn5epqzE2gJX++8YVcAgIdSVfXK6rVrViOXOa/3CMd3zfp8Pc3ZCexS4ft/QH9DAAAYwidwvDGrql5TOFVer6s2UmkKxyMcmrMTGRN+rvIRPQBMpTWB42fh+BSOIhxV9srqVdUT4ezJkPBXjQUAMEQV36gx62fXv43+EQmSvUSfq3oinD1x4ecfkv+gtFZ25Q0AADI5vskTODq7Xln9H9HJXpL/LeqqnghnTx5HrP+D3dzc3EQt+/u0XPoAABF1fPM51oL2ql6z9WrMZtlrAqeq6olw9qSKdCrZ6x3ape/rpvg+AHD5VPGN75bVXL2q+texFrrn9Vqaq29V9UQ4e5KFn39oytz0HzxL3/8e0ge4HirR+6il33pQEzg5wvHrn9Gv6j/EdlVPhLMnOcMfEr7+43t+xn94gOtDr/sqp1d846dbelXvkpfoNVc/lNVT1R+AKtJx2avRouWVvkuf6h7g8hnL6fOopebqJXpfyukV3/g5OL2sPpD9wRiLdPRD/GBLd43xaR0AuExydNvK6V30msDRuKVLXjm9TraU6KnqT8CQ8L26z8L3H4xLn0of4DLI1Xx2g59q6TP1Er1HOFn0rfiGqv7IfBG+jWbm/F55nN6FJX3/Ad0Gsge4BCrRe0O2yuk1fZNF7xm9xzcSfdWURfRHZEqko3dwzdD6r1/+jgwAyyWL/nPUovfNUz5Tn0XvFb2L3mfqfdTyc0QwgXNkhubwq3dyLf+h3UXEo1hX+RFU+gBLoZXP54zee3kSfTVqqauq+tyQJb45My3hr6Jf4evXNmVv72L9g38aEV9tvs/nWIt/FUgfYM4M5fO5mldFn5uyLns1Zz2+8V2yVQxMfHMGesIvcvxq88TrWP8wX0TEs4h4svk+yvFV6QPAfKiq+VY+78cWe0Wvok95vRq0XtHrVoO+eSpv2CS+ORO7Vvh6V/8rtoWvWEc/RKp8gPPSkvyY6NWzc8n769894EVgK6f/UtEHVf1ZaR2PrB+QRq90Doa68C+jE/7Xsc7xVeVHkOcDnIsseV2rfH5M9K9t/ZU+riJecvqZsyX8TawTUQtfmd2LiHgetfBvbJHnAxyfKZIfa8RK9N6MzVW8mrCSvGf0lejJ6WfG2A1QPMfXCNYfsZa9hP8kauFHdBEP0gc4LFMlr8ItH5WiRqyLPse2rchGc/R5I6ZX9OT0M6QU/qbK1w9NTxIJ/2msRa/q/kl0kzo+no80uEIAAARNSURBVHm3uSJ9gP3J4syZfBXZ5Go+T9zkqZsc4eTYRn83n6vVi26Cqn62jFX4ucp/G+sc/4mtr6I/i+9il/Rv0hUAhmkJ3h97Ne25vLL51sSNRK/45k1x9egmi17/O71mbCD62dMU/qbK/xxrSXuVfxdryWvdRVv4EV3U4+OaiB+gz66Cz1M2ObJR5NIS/Zu09Gf6Oo9uKtH7v4foZiEMVfhCTypV+Y9tKbvPsvcnqMY2I7o5fSIeuFYqMa6K65Dgq2o+S16xjc/R+8pVfJa8z9BvNWID0S+SQeEXEzs3sX5CPNqsluz9yenS107cvDkL+cOlMSR2f+zXqYJ3yVdNWK/oXfbvoi94H6f0HbGez+vfQGxzAYxW+BbtRKzF/CG6iCZP5ejJWj1B8zRP/rsC+cPcGRPemNirNUXwWfJezefopiV3rUry5PMXzqjwjVV00c5NWvq8xz96curx0+jP7Ou3hOpNA+nDHMnCa308JPecf1eS/2jXLPgc23hV78J/H33Ju+BbkvdpG/L5C2SS8ItoZ+tLontDaGWK30Q3yqlmr0dCWfxIH+ZCJfLWdUjwHnPepyXJS8SV4LVJ6u/YFn4Wv39egs9xTY5syOcvnEnCj9iSvp6gXz4d3ZtBHgVTxfEyOuk/jS7iqRq/OepB/nBqXHaVyH3511SCl+RVRfs1xzWS85Dg8/I3BF+V5P3f4//WiCC2uXQmCz+iJ/17/ZFd9eRWlfIh+g2jb6OT/vPopO/Zfs73BcKHU5OFn0Weow8XfiV4l7tLPss+xzW7iN1jmjHJ996wEP11sJPwI7akP1X4ryPiVXSHrrn0daZ+3sDFAWxwbvT8liRzHFPJv8rjW8slnSv7luDH5O6CR/LQY2fhR0SV6Wfh6wmsczq0VftFdFW+4h0/oqEV7wCcAxdkFrkL1cVayf6f4rFfW43Z/Lks+Orfkt+EkDx84UHCj9iSfv6VtlXlf5OWhK94x5u5HusgfTg11W+vOZ6RbLPs76Ou5qvHUz+fBe9vNKuoBY/koceDhR/Rk/5QtKPpgTfRCf5ZdKdtKtZpCR/Zw7nwIsZFPkX4VZzzKT3OuX71ZrKL4ENXJA8VN4d6XmxujXgTXf6unbh+9s6TWMc3X0cnen2sr/EZfRq3cA78RTFW4edIR7/hVl9bidzX5+LxJMFHIHkY52DCj/gi/YiuOnfxS/75DeBJ9GU/thMX4FR4hZ+l72L2zDxX+kNCz2tVXBE8HIyDCl9Ytd+q+n3lWfxWwxbxw6nIFX6Wfq7qs6ArmU+RejQ+Xj84xosVroqjCF9YxS/pZ/n7uk0rCx7hw6nIL4pK5K0qvFr+df79stSROxyVowpfJPFXlb+/IfgCmANjQo+Ra1PsEcgdTsdJhO8U8vfH/jHAnBgTe3689TFih3NzcuE7Jv8IIhyYL4Mi733inC8ogBHOKvwW6Y0A4OwgcrgEZil8AAA4PP8PlwF1LKovKugAAAAASUVORK5CYII="
+         id="image26" />
+      <path
+         class="cls-3"
+         d="M481.63,233.68V382.37a181.61,181.61,0,0,1-.92,18.31,178.64,178.64,0,0,1-11,46.34c-.38,1-.78,2-1.2,3a176.45,176.45,0,0,1-13.76,27.11c-.93,1.51-1.9,3-2.86,4.49a180.19,180.19,0,0,1-133.39,80.11h0c-3.33.3-6.68.53-10,.66q-3.45.14-6.95.13H151.69a30.93,30.93,0,0,1-30.94-30.95V382.91c0-1.77,0-3.55.08-5.31A180.19,180.19,0,0,1,285,203.43q7.88-.69,15.95-.7H450.69A31,31,0,0,1,481.63,233.68Z"
+         transform="translate(-112 -195)"
+         id="path28" />
+      <image
+         class="cls-4"
+         width="139"
+         height="171"
+         transform="translate(40.77 189.77)"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIsAAACrCAYAAABWtW/JAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4Xu2d2XbjOBJEQ7bLtfc+//+B09NdW9duaR7IMC+DCUqWJZmuVp6DQ2ongYvIRAKkVpvNRmc72y52se0NZzub7WrbG35EW61Wq7mXi+ea8rv5F0nz6kc+1wYUq9jmfj7OCuLjTWyHF37Aiv2hYAk4Eopqm/tzirNBUbE/t/0h4Hn0bgiAVA3fKnzfxcx7pDEkLuvG8wZiHY835PixgvMolSUA4f7FzHbba/m8jXCsUarn595TKdOjAufRKEsDkGzgSw0Nf7llm+/LYlsX5abY57Z6LuHaCIrzGKBZvLIUkFRwXEa56kvubyv+Lv+OlSBBqMp3bFn4GiFL9ZE6ZhbbIIuFpYekUhAqAoF4UpSr2GdJuPi4giWhqMD4NlP8+jZ4pIVCszhYZiCplOOJpOsoT4vnEqBUngSmBUuqx43GIHwtypfiOQLUAkdaGDSLgSXcTboZNjABeYryDIXPJzTbYGnFLHOwuBCOz/3+l34/Hyc8/M5FQrMIWKAmdDWVgrjxCcbzohCaSl1aisKYxZYxS+WGEhYD8UXSp37/U5TPGkOUirM4aB50NBSQWElc3LCpHM8lvcCWpQVLuqHLKDkqSliqkU8C48ZOYAjIx6IkPKk2/p2NpPVqtXqwkdODwQJQGLQyICUgBOIlti/xOJUlQUn3Uw2XDUrCQmBYdlUYwvJPoyQ4VBtDs1IHzEYPoDInh2XG5SQkVg4D8QrlJbZUFcYrCUoqCYNnHo80hUUahrkVOBU0DHArYD5gy/IP3teCZq0HUJmTwlKoiWMGxyQJyStJr4tCVdlFTVJJ0v2xCFtpnHGtyq7Q2M3Y/VhR3quD5D32E5xPGkNzo842q9VqLZ0mqXcSWDDS4SjHauLAlZAYip+ivNZYUVJN5pRkGxgExI+zATbFltBUwTChocoYmJ/UgfFOHSze+tw+qDsnQ3PZf9dKY2iODszRYSncjtXEo5RUEoPxc1/mQJmDpFIRYWvLx63XNqq/IwEyNDnkdhCc0FhhXqmD5JU6YLIzfFB3fp/UnddXfO9J3NJRYSncjt0CXU4FyS+awkK3ky7HAM4FqjRWqJXhLsbvTYAuNFWcJ+qgudagNF80DtoZl1WxGPNE7hBf1P3ud3V2VGCOBkuAwtjEAewLDTGJwfgFxaBYUagmVcX5typAWvGGin1ubQQi97Pk+wyP62CtrnGZL6rSAC5VGiDjMP/ejaSbYwFzFFgAihvSauLYxHHJTxrg+FU1KO5l7F1WE0NSqQjjiPXMfguiNMKf22o/i6FZa+qKM480l2CsAvc8//VqtVofGpiDw9KDwtEORzqpJr9GMSyMT1JNMmi1pfTnCIX7mR2twLFRLS6KkoF0xkwu/g6+70ZDHTHYNzxPo1SZ6ATGQ2wdGpiDwhKgmH6qySsNLudXSb/1pQLFauIANnuSNDRqBQcDyyx+ze+vgKElKD4OH9NVFMZRCU8qTgWNwSE811G2qevBgTkYLAUojk8MioNXQmJQfu1fs9vJoC57TypIK5PKjGo+x1T6OkoqSwULwagaOZ9PcCo3RZVqfXfr+1JppQMDcxBYZkBxpO/g9VdJv/fFsDhGMSj0zxzhGBI2apVmZ/mC0loisA0WaepSEpRUAboSP78t3uBjAplgUsFSWWxHUZh7wxKjngTFbucXDZD8obGqOJD1aKeSWKlrQDdsApIzvZ+LktA4E1q5I7qi7PkJSytIZbD6DKVyI2xwdhAqWQUPOxLBSzsIMPeCpTHqSVCsJn+gUFEYn7AS6XKoJNsm6nIpAGd0W0sBqC5VgFu5CsJCJTEgzKEwZ1LliTZqN3wCw8LPVJDQ7g3M3rAUeZSMUQyKAflPv/1dU1AqtyNN3U0Cwql+zt5W0/9UFoOyTVVsbEA2Ft1QwsL5q2ryM6cqKrVgp0m1ISQsaTyX79L+UwN7wdJIuF1rHMza9RiU//SPHcwSFPtiV4DVxG6CKXKDUM3WepsKk+7HLqgaQleVmOrC824BQ1g8wnuNfZ//C3XnyA5zhd8jMHOlsjwXP94rcbcXLL2lqjiP8lodKL9pDMofmgfFJ8wRjhvYjW4g3qO8w3NWl2pdCOdSGNhWQ+ZKWeaASZeUwBAUT1987B9/0Xj2/Frd7zOWudAYoG2w5HmkYm6ku08N3BmWRtLN7sdxym8axylUFAezBqUKYq0mnGwzEO/68hb7ntq36rRWneXoh6AI25ZVwLghXRjDOHbhTHqqn4F+pe74nqs7JkLTik3mFIXnli7W53knYO4EC9zPSuOA1qD8pCGPYkg86klQrjVUAt2OJ9nscgjJG3WQeEtQrChVIDvncnYFRRoap6UydMnXmq6M+xCPDUxrgROH26z3a9WgJBC7QLPLeUu6Iyy90f24F3n041yKlYWgZDBrRfFJeKRDNTEkBuTvfvtGg6pYUQxKBUkVwCYku1TaqthW0HzV4Jqeqg7GGVdVwfeNuk7oY2VMd6naEhB3wKyHkdvddYS0MyyN0Y+DWuZTMjP7k6YxCkFJt0M1easOEBarimOUbb1zGyR3sfxMQnOhwd0ZGgbnHOa3hvaVy3ymARjXXQKT59iCpYJmtYs72hkWjXtPjn48MWhl8VyPQfFkYAsUVybVxEryV18SlA8au50cDrcg2Vopd7BN34k26s5pje2NBngyw/ylUVrZ5TzeBIYdwKC4bl1aWWt/tvqdke0ES18h0nCAGdR6qMwJwV0V5YsGt2OXY0j+p3lQUk2qmETSQQEZGb6X4LjBLjTu3W64r1tKBQuP3x2XMYw0/m3+nkH9pjY0q9VqtZqrp51g0dj9WFWeaaoqLVAYo0hDjGJQPmhQE0PiYvfzVuNA1qC0XM7RAGmZf6/vWy1ovkeh4rAheV42dtonGtyfO3DCQhefuSZ/P4GcdUdbYYGqtIbKXAppUDgpaFAu+u/ZaDgBu5536oAwIH/25S+NFcXxyWzvOzUkaTPQsGTP574bsVIUqspV7EtTZWm5v1Tkjaa/N7KtsKiOVawqdEE/qwaFQZkVxcNjg/JGAyT/7bdWFSsKr6Nhr3DlPDgkaQU03rJBqQJV8CmN2yBzLpVLqmBhkM0c1ESZW+oyC8uMqnioXK3CZ0BLUDYaxyke9bzV4Hr+qwGWChT3hpGaLA2SNECz1lAXBCJVJ0ExCBfYZpKOQ/cExiru0ViOvqjSPp67waK2qtgFMX3NhUuZxmdP+qpxQOs45U+N3Q9dj0HJE1qcmszZZrPZzKgMIUlFuUS5wn6lMpf956/V1VUqSzXBmgqjKthtwtJQFQ6XrSwGxQEt3Y9PhKD4gJlHyYDW2VmDYvpvK/QxQUIrVEYaw0NjZzUoc7DQHTG9YbfPPE9ON2T8MlGXOWVJVfFkIVWFs6hWFYIiDe7HhHP0wzxKFcxWivJoQaFBZdgoPK9UFbfBlbZDs+pfd927zQwLs8iMBeni16kuJSyRV6ELcrzCibF0Pzn6sap80zjx5rQ9h8ZM3ycoj87tbLPCLUnjBrdKJCwVNFXQ6/jlmbr6f6XxxCwnNTMmvOi3t7aLsqSkObh18WKe1jCZoDioZfKNCTeCMhoa/0iQ0MIt0VrK4nDAxeBQYSp3lJfiuLzvn/+I7/ref36Ud2nBQjp9kFwF55jFcUqm81NVqljlDQoVZeI/f1RQCnOs4MbKeKUFC4G51FSZGG/aM7CzV+3nz7fdUAS2dEGOV/xjXB5YgeITz1glYfEyAybcMtn2w1vEMFLXUF81hcXhQBYC44YWPu/Psh294IrXZxGWkW1TFh5kLubhOlIm31qxCgNbLl6qMrM/VDC7qwUwrrsMBwiMrxhwrFi5JGkKzLbPUplurYIlAyQGt/Z7JJI/5IOTBjllWp/KYlA41zOKxv9NoNgawLQaO5XBbeEGv9JYYdimWaogeWQjWIpRUAWLD5IHmEQ6H0JYuE4lV7clKP86SGg9MHRHzpM4CKU7abkSQsJEHy2haIIitZUlKUxYKpJNpWMV5lYMSw7Zqtnjf537mTGPJh2/VLHHHCybfn+jYaKS82ourQzyyFoxizT1kw6knmG/UhXC4nkgwlItVh5NZp1BmeRgXJceKLg9UundeRk3Xvb7jh05oZizz1T2SRvMxSxWGA7ZDEgVTFm6/EOpLMweGhQrCtPMZ+st3FGVBc9A1W3iUOBb/5z6fYcCXDiebdEEZm40lMGQAWlF3YSFysJJrJy8yvmIs/upbc4dsQN7kLHREOckLLxKIlcdZtw4C8sqSgLzJLatMTlh4axntfDmHNTOWLgjq8WlBnfktiAoN+o65QuNYfmk8ZzcGw0jUqqL45fR9Mo2ZWGg63KFfaoK4xWOhgyLyzcViqIzLE3rgaFiW10+atwmwusf1cUyCcsHDctCPCdXwbJVWaRaXRIYgpSqwpjFxdAQFEbiG2lM8dkmZlhWGtw720EaOuhndVA80wALn+e1WFSW2fTFLSzIsdASmITEn6ncEF1Ra8hGes+gzFgk61YasrtUdaqKF8u7jW805Go888/LficxS3beuaFzKoyh4WNha2Pj0y3luH6D7RmUHQzu6KZ/iu1AF/VR41UA0jCa4qg0R6az8WMV4KZVcLRAsRGUansGZH9zvdnl+Dk/tnowB8b352CDs/xNVZHmlUWawsDHCY+lMG0zU852Rwt3JI07JqdXOFr1+3aKH1ux49xo6GwLtQCGsBgGj5Za+a8qdpwFRWrDcsheX8U+dGVn28MAjDRu8BtN40upDg1GYcG20eg2N5Qf5uNNbGk+yIvG9gzLAaxvXF9j7canmlSwcH8nSGwJS/WhjDFyn1tpeqCtPE1F/9n2sIDGyiJN63XSXruCIs0ry6You4xmEpArlMsoBGWl9neebQdzw8M9lfV5F0Bot7D0PrAi0ZBkqWCii8kpgicaz2WkypRXwZ3t7nasOrzQ1Co1qZJqhIZGZTEk1ygE5hzDPCKrYJGmakJQclyewBgWKkquSHfCaG7m+mwLs4SlUhUD4mQOt0wP0w0RllxgPLckc9WYozrbAmybshAULy+o1qKs4/OGhetFczW6Z0QTmLMt1LbFLGuN08NeuDS3eKmlLL7myCWXAt7OZp/VZZnWUhZprCwGhSvdcllkAmNYeL1R/tmBZ0bPscsjsJayMLC1C+JaWq6jTXXh0JluiJe9toA5q8uCbQQLxucZs1hZPmsKS7VEkq7oiYZ4hf+QkRdlE5gzKAu0XWOWXKE/e4spDbB46OyYhXeMqm4CxGD34qwuy7K5dH9LWT5pDIzVpXJFFxpcEZXlgzpgeMGZoaNKrVYz92U922ltAkuf9s88i4fMhCWX5H3TMLKRxil/xi1WFv47Rl7GmtMJZ1uAza1nmYNl7n5kNxqn8R232BW9wmd5i6pyeZ+knf+14mzHtW2zzjki4mLfBMbqwklCDqGpLq81VSfCwmH4GZiFWAkLXFHCwksJ8iL3LxqysjlJSHV5oSFfMzeyoiv6Lp2BeWjbpizpir5oUATfa+WDhlFNwmJgPDJ6qq7hX2q6yjwD5ZygPAPzwDYHizRN+VsNeJ+V9+rcyj8a3/aBi5syo/tCQxzk4pEQZ7RHrkhnYB7UmrBgMVTmW6gs79SB8k7tmxFyGO3YhROUhKRyQTbnXG6BkXQeVp/QdlWWVBe6obca0vgtWBjsPsF33hSlckG0lXpgpP3/0Ppsd7dZWKAuVdzi62Wr25xWk4MEh8BkqXIrqyh+7kYdMGeVOYFtUxZpqi4eQjtGeR7Fq+G41pYNbXfEAHpTFBs/x6D5mwZgpLPKHN22wrJFXXxbhxYsGbfQHd3+BLZzkFxqDEw1gjqrzBFtKyy9cQjNQNe5k7yLZSoLFSGByRGPrYIli19j9ljqVUY6Q3NI2wmWGBlV6lItyG5d8pHxy7Wmxvf581covKyE90PjVIGV5gzMgWwnWHqzuqw0Vhc33nVRUl0cnDLD64DXlvGNgTEc1WUlecdFD8EdAG+k3S/TPFttO8PSq4s0jl0uNQaGDTqnLIbGz13hORuVhd/7NMp7Db+Xc0wXgtJYHR8TNLus6TnV+ewMi3QLDOOXrxoalC6CsKSyEBY+tkuqVIXfa0iqOInzVMwM0zWtlx7PBCCsr8pOFp/dCZbeDIvUncRXjeMKqwBjjISFxtc4SqKyJCwExaMw/mcRlz1wgvJ7/72LjWd6UFoljamGoyvnnWGBO3Kw+11do2wbscydtDQFZk5dDMqLKL6pXt492pOVFwqlWQowBSQXUbLu3Gm9HSnnMc7pzrBIt8BYXdxb2bBzsKRtNCiR33OpeVisLr4W6WUUz4bzDyWuNEBjpZGOWLm7WoCSdZjpB5tDAZZb5VwdYbJ1L1hgptoH6ZPldhcJdeEoiZ9vAcML17wY/B22VJsn6twTv/ebOnswYACKYcj0wDWe87FT1b+hWDmPMju/NyxwR4xftpXbj0fhvNBdgKE7MiyeBed1Sc79WLFsG3UV6+M4qQUorXPLjLhhcfqCi8hcX9IRgNkbFmkCjLOn0hQQbzfYGpCcbfZIiu6LMsyKpcL46gEWTm4SQqlQtgdQF8LC88lYjOewUldP3zRd5pqd4bsOeF73gkUaAWNYVupot1WNU/nbhMY9KWOeXWMYV7JX77FX5u9T2U5iGB4blCfqzoMK+ZPG11Y90QALM+jvNXQGaVzP3N7L7g2LNFEYB46jt2CbDUW/a39L1+FjJCzboGnJt4/Pq/Q4ReDvv3el7mh5Dtca1PFnSb9I+rXff63hQrwLdcfrmf93eF6qO8JB7qp1EFikW2A4Qpq8ReMhnrPALl+xfamhEZngy6CZbokBIacCXIlOIrYWil+oC3TvXanbDKqSLui5OjB+lvR7X35VpzAvNYXlQ/8ZuqfvKIblIOpyMFikrcCkC6KicNF2JtKeawCMw0hCc9m/zqGm3+dgkFcmeFhNV/fQyuJY5ZU6VflN0h/qgPlZHSxP+88Zlhcau6Zc1+w6XEn3V5eDwiI1ganiFbqDvDTEJ8qlB880bkg2sB+zsAI/qwOluhA/YTmVEXTHK74I77UGN/Rbv29YLtTV3WcNSrPWsCgtr0UfrffRPezgsEglMK2YhbDQNVBpLKl5slQWadrYa9UxzJJAMdgMcAnMzyiExcpyqa5O2CF4Pde1hjq8t3IeBRZpBAwProKFbqhSF/veFijZ0IxjroqSw/BTg0JLYDIVkNlpKsll/x1WmX/UAeYk5DMNmetL9XV4H1d0NFgk5bCabsjFqpHuKN3QRuPeWA2phf0WTJuZchKL4DbPiYG6FZDFyrLuP2f380nje9607qpltd/LjgqLpBxWS9PYJUdFLASFlZkq4ffQ8jeyGNiTAxOW0LBcovicfb7SkGZIBXJ+yaPCgwTxR4dFmgDDxmGwa4VhjGJIMo/ytH/PlaZujurl7/4axTDSxT0UMNtULhXyon9+rUGBmJC0C2vCsq8rOgks0ggYHyQbNctGYz/+TENms4rw+Z3+3nRvHikwv5K5iKNbXw/u3VXHmVM/aVDQTEhybY9hcVKSKnyjPe1ksEi6nZ/oA9+qwlwhBsW5B97HxYqQlSiNK92wOC3uVXR5A6IKulOZf9NwEPBUPwLNOIeBMYHJLDjd0F6u6KSw2AqVoRmUSgkICisv1coVT0XJ+8FUyrLZR573sEpRCEqVnORx0iVRXZgqaCnLStJeCboHgUWaqIxtpaFHVZnIORXIyvd3cGY21+imspzSeKw8XgPOdELrOFvqQlXJEZFHRXc+3ws9sPXQZMyybdTSOtFtsFhhMmZ5CBckTZWliq/cYXZVF0PDiVTCsrfd68NHsAqIfEy/W322Fdzm5CErfy2dzAXZdj3eVnwlTWOXBMY5mypmubMtDRZp3MO3AZLW6qk5hTAXJB/deigJS3W8CfccLBUw3mZOalsdNm2JsNB4YqtGsbHy3VvdY7eOME6sKraWurSUkIDbKnXhNkHZteNNbOmwSNshoc0B4/25HMapjce6ixpmgM+4hRnfK+xXc2F72dJhSThyn1tpCksGy62A+eQGJUtXZPWr3GaVc5HGwBCaag5tL1WRlglLBUE+br1HGkOwxpblwSAJ2wZMus+5YX6qTKrJpK4wqbmTLRGWQ9kmtku1VMMEpnKf7BCV8hqaVJM7wZH2I8Mypz5LslRCusxtoNBarroFyZ3rZYmw3FcJqt61kyyf2iJuSWiq0gLFxnPK87v3+S4RFltWCCup5WIISRXstQK+pVhCU8FxiM60ly0JlqoSqgqbAyZhcZ4hcw4VNEuwjC8qoB/sWJcEC62SZW6rHjcHCrOa1Szs6q4jg0NYY4ll5TYrNdz3ePdWpkXA0sieEhQHftv8tys6Z2KzcL7kodUlIaHLrNRw7ljn3NXekNgWAQss1SQTalVizZ9jhecaj20ryFaS7px3OJClmjBtn0pYpe1trIvcb3XGO9nSYJHGasK8Q5YERhr3Tl6Hw/u4JDCjRjgxMHRDORHIYmhak4EVHJXLvjMgtCXBkie61nheh9nMyfKC/jtSWbwYyOt381IJAlM1wtGshzJdT7UmhQuYqtnjBGVuyD2yu06eXm17wwOYT4yJKS4znEt/p7Jca7gzga/y838jfVJjAdTqgDfAmbGExerRWktbrUuxVWo8Nxe217ktDZYEhQuCco1HKgwrMd3QSw33O/EdLXMdrn/7u3RcYApVsRJ6SWS6TKsLXaaNoFRZ32pgsJctFRaeeGu1W7U2NYNcKstrjW972oJFAjDS3eV6zgpQrIBWk+rOVc9UK4vPO0HhRCRjvHupy2Jg6Vf8uwIYr2xbR/tNQ0VK44ZwI7xQB0vCllP+rMCbfnuw22wBFA6NE5RXGsdXvutDwiJNQXF9Ve46XfadbTGw9Ebq16phyZsiszLSFV1pcEW+QI2xT7U+xJ//1m9vpPvd/x+QpKI4PvF9Wewqf+r3X/WvOdClC6LLJii5cCrd9V6qIi0PFlu6IcKy6/9JpyuiPFfSLA0N6s8bmFt/b2j695eKE8PvChRCbBfpW4P5FhuvNVaWUU5ItbuuFnq31u/e2RYFS++KWjFL6/+kP6seAmfD3BQlFYWJsU94nIGi+s9tAgyaAZHG38sYxaD8ouHmPb/2+7412HNNryqUxqpCUHa6mE572KJg6Y1u6EZdr/ii7uR9iy/+n3R1e4nL/rusLvy+qtISLpcnGi+Y9ndsimJbFaWKURxH+ZZgv/fb3zRWFp4bXVA1AKDyVpfp3h7vPu50ibBIQ+PadRiWjxpuVvNeNSxUFrqjpxo3rLfs9QbEvZ9XMKb7unVN+D73eqqUfz+D2VcaXM/vkv6j7h5yvkMl45VUlVZHSuVtKctetjhYMCoiMJZZKgvvok2ppityo91+vaYqQPfA+aRnGnIyBCZHF9kA6c4qUOh+fN8432yQsOSQWarrxYpixU1YfryYBeYKYaU4bvGfjzMXYWXJ4SWDXfWvS20XwUSe7/vPiqdLYm91HCPVSkUAPTz+SR0UhoXxyiuNh8w+jypOcZ1QcTPxOAJlHxckLRSWyLm4cii379WeGCQshkEa3AEtlYXxxEuNe2p17TGBsVUujUPkhIUjICuKYxWCIg31UYHyri8GPN1npYJ3skXC0lulLnZFTovnfUha8ycJDF2Un0tYXmn6NzQcklZDcMZIVCqqVc5TMadiRamC2hYo7yS97UsLllug91UVacGwFOriYO6jpjOzhCVjFhsDXhvVx41LWKpheqUuLVh4jFwqYWAytV8ppFQHtATlTV/eaoCFwe29VUVaMCy9WV3ST/+jcUNQVVqwUHH4esKSWVVD4p7KDHA1N5VujfGK1dDQVDPLBF4a4pQKlDeS/u7LGw1//XdwVZEWDkuMjFhhHL0YkgRFGkY/LgamCoDpjqwEmTr/qjEoVBZbuiECYzeXimiX43PIGOWbpq6HoPytsark8ot7q4q0cFh6s7pIXSV+1dAgl7F1o/tzLpZhK9BGU5VhYOrG9VD5K/YNSQ6hU1kMNAPd69i/QiHEUhuUt+rg+AuFLihV5V4jINriYenVRRqry4WGdLzVhK6FkNxo3Khr1bGNH7Oh3TO/xz63BsWwJHi5pYLksUvj42ac9kGDmvyvL3+qg+VvdWqTqnKQWMW2eFikW2CsLh4RsGESFELyXePGfq4xMJb9hGatrn78XevYT1AIC4GptqlqNncInyNjFCvKnyj/UwfLW7Vjlb1S+5U9Clhg2evYOPm6AWFswVIFlAmNv9PQbIqtiy2BqbYERJoet10Pg1kryp+S/qtBVd6ocz9Owh0FFOkRwQJ3xGBSmoKSqsK4g4X5DKpMugU2PMFISKwstgQ5AZHGx2yIq2z1G3VgGBarSsv9HCyopT0aWKQJMCt1FSONGzB7qEHJkQ3vcZ8qU8VBiv19jfFUHqtTA9Xw+C+NXU+CcjT3Y3tUsEgjYG6Kl1vKYkC43sNLAJzvYL4mobGySFOlaMGTqlNBYnfqY+SkoBNuHhrn6MegfOw/a0W50RFAkR4hLNIEmGyIjcYNYVUhKM7MJjDV1EEFzTa1oYtijFOBzECWs8dV0q3Kp+T8z1FAkR4pLFIZwxAaS3El717m8EHD/IyBYcq9ck0taAjMJspcHGXFIyh2P4bFORTP/eSyCcc6a0lHu3xFesSwSBNgMm7JoDGVxbBwJT1nshOYVJlqBCVNIWFckmqSoFBVWLz0IGe/GaMcFRTpkcMijYAhLGywdEdUl/eaTupxzobp+ARmW1ItIWmBkgC/jy1nvdPtHDVGSXv0sEi6TWWvhv9kTFha7siwvNBYWeyOMobJeah0TdL4dw1qBYqPw7BQXTjbnQuvrCZHG/W0bHWi3zmZ4RodN6AblHM0nAX2TDAV5bm2w0JoWrAwPqlgSWA+RfF7OXF563Z0QlCkHxAWaQSMNLgJxxk5sccZYAKUs8IJSzW8lrbDkjmfzyh+7Pf4cy+OKrkAAADzSURBVBNIdGJQpB8UFtsO0CQ4VXmiKSjVZGALFgNDV7St+L03KP7ek0Ni+6Fhsc1Ac6Gh0ROeK00BudQYkm2wZIBLeKga3+J1qoiL9ICgSP8SWGwFNI5trDZu+AqIhIPbaujsBqc6fC/2nSNh0GpXswhIbP8qWGwBDQPiCqBUonyPH8/lWTLnkvt8vz8vLQQS278SFhuuU054CMAujytYCA23rX1+9iAr2w5t/2pYaAGOt7k/9xptpA5R8jk/XiQgtDMshQEcaQxCApX7tE1sy+eWDgjtDMsOFvBMXm48X1bsY4Ij7QzL2Xa2i21vONvZbP8H0BLgOumby0sAAAAASUVORK5CYII="
+         id="image30" />
+      <path
+         class="cls-5"
+         d="M277.89,432.22c-13.88-27.49-45-43.24-75.06-33.74-27,8.55-49.43,35.21-38.18,64.41,6.5,16.84,20.74,28.48,37.19,35l-4.18-10.29a37.58,37.58,0,0,0-.09,37.73c6.77,11.51,19.33,18.42,32.46,19.48,12.25,1,24.83-3.65,32.39-13.55,9.43-12.35,8.61-28.71,2-42.1-4-8.08-16.08-1-12.09,7.06,4.13,8.36,4.91,19.18-1.16,26.87-5,6.28-13.42,8.57-21.12,7.72-17.55-1.92-29.47-20-20.28-36.14,2.43-4.27,0-8.64-4.18-10.28-20-7.93-38.46-30.93-25.74-52.46,11.09-18.76,36.89-26.71,57-19.61,13,4.59,22.9,14.88,29,27,4.06,8.05,16.14,1,12.09-7.06Z"
+         transform="translate(-112 -195)"
+         id="path32" />
+      <image
+         class="cls-4"
+         width="68"
+         height="95"
+         transform="translate(75.77 223.77)"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEQAAABfCAYAAABRAmHqAAAACXBIWXMAAAsSAAALEgHS3X78AAAMe0lEQVR4Xu2caXfbRhJFHyhZ8SI7sZ38/x84k9iWLWsxl/nQfdUPxWoA1GLRJ1Pn1AFFQgD74tXSDUjDbrfT/63Zam6Hf5udzu3w2DYMw9D7qG5Tye5+kpSHpz5PADB0tpn5F9uF7ZMBehIgBsG3mfs+0XbB43v8/KhwHhVIBREhrMLrVfK+Q4kgtgteS4XLgwfzKEACCB8wftLZOiDMB4xvOq9x9pceCOZBQBIQEcKpbU/DzydqYPw4DG6T+LqzjYCke4K5d5UxGKjhxPxU0gvzs/DzCzVAUSWuhLX5j47zmYPbSdoOw3BwfrkXEIPhIBjgWfXfOs7nQHGVEC4Og4Hfmt+Y87MD2tTjbYdh2OkAtRwMJIGBGoDwUtKrxF9WBwpKAShAPFwcBgCuq19V57UDcjBbHaCWg4BUGDFHAOKVpNfV30g6r1vei1AcSAwZV4grg8F/r34Ztt/rPg5mw3GXQFkMJMAgPFAEEN4m/qa6AyFspkLGFfJDTR1XKgAuJX2r/rVuf1ODw3F/qNggaTMHZRGQECaECDAA8U7S75L+qNt39X2U8krjPOLhsmpnG4VNzCGEy3c1GBf1+Bcaq4+EjfLWdTsJZRZIJ2cQIudqIN6bAwWFvNY4f3gJ9rIbG7KYXKNKvmkcmpyjV8Hujt2DMglkAsZLNRjvJX2Q9LFuP6gAQSEZjF4PIuVQXC0o5bv281QEkoHGaOhGNqcQDugJlDABxkdJf1YHiqsjyrgHwm1nW8Bs1aBQuV7ba0LSoWNpVzsMwxBV0gVS1SE1dZA3XqsM9neVwf8p6a/qH9XUQd7wEIltupRcJduH3AIYL+9Zf+O5QxqDpAx780YFurMphcRQOVMZYKaOv+r2vQqoc43lm8Zx2Lpx7riV9vsf73w9QbuiKNskaPqTIeaSFEhHHZTXtyoqcCAf1ZLpuZp8/Qt6OXV3KUtt8JzbHTi89v0c+kZ530KP8kPj/HJnPYX4l8pyB+HyQeOqcq4CDRic0K8WV8y7SSQstXMTZtn8BwCcQ+E8N2qlmTxDHovwRrYHJFGHhwuV5Y/g77SvDGDEkslVit0ks9R4Xi5GlitInKiYfZk+eCOYJfQ9KJlComQ5yWuVQZNQY68RYfjVctnizD9u634OBGX05kYxP0V1EWIOYRIENgJi6uDATh0g79R6DIdxpjEMVIF0v5p/U2msrpUD8QtBInf3MKDfoNXP1ki8jE/alEKy6oJC8PjFuFoo41IFwBdJn6t/UYNypRY2USF+IeI8iVz1Si0vbOuxUJ8nUMpuBLRnEQhyymSLQvAMhtQy/JXKoD9L+sf8k8q8AyA3ykPGFeIXwudIJPBTlUEC5MLOQXVxJQKl36km4eLNGF1hlOxLtSsUQ+VS5Ut9kvS3pP/U7ScVlVyqKaQXMpz7jYqq3qoMkiROJ8w4ftRjcl7U+F1jtcwDqRYTaswhcW2D7E2oEMdMvi5UFPK3pP9WRyF+5aaqzEu1ma1P+1EIF0Uqg71WU2ZUY1TJ3gRvKod4yBA27l7KsqrC1PxT9X/s9Ve1cCF/ACSe/8qcxaBvGq+xeGL13HWhpkaHT9+zSCExqTqUuXkDK1zXal+KpEpcf1ULlyhhDJWeKl86vFQrwVwYrzQRHkB657uzuT4EIIRObIqo7dK4G/WFnEvz3hJf/IJ8h7XKeeLU/0rt4sQc5heFauMV504dc+sh3rSszFEKcHidtc2+7HcbPLbqntjcpTa4lR3Xodxo3M5zYTyPTU3qtktXzCKUk447MIwBkQ+8OfJjO+gs2/vPHCOCuVW7KHwfzPdb2+tZGFIFYiXXracY3Mt0lHss3b6OwZVi37WaIrxHwLjqrsJVPU78Luzvx3I1TsKQ8hwijWHMuf+Oh5jPQ96oyHxT9wOUz2ViN+lgGKTqlnP5d/AL42q9C8c5GFIfyCEWw4u1EzrMa5WBSuOGyxNeFusx2fbCKlO3f76TNHs/BusB2S10DCje2b5V6zEGNVBv1FpqX7jx2W8GRkoGOmVLIbidSuUXkzziA98Gz66Qt/pv1OIeVRA63nWypTzTgNF79CrTvQa7xKJCIoTNhLucPS+8tPf9PZYf/Y4b/lVjUN/r73n/gPHdnsQcSKYIL1/I2MsZYOgUUYPUGjtXh4eJw7gIWz6jtF6rVZaNJA3DMFsx7mNZDsmAkPSyO+wv6r4kVqnlFID48gFhQffKLPaL9ieOdKErFSgcey09DZReyADDO8PrxH3FSmogeB1nrT9UBn2jAoe7b0zl42pYNk24qcd/EihTCiFMgBHnJUy7qf+xnQcISnmhApnmjDWW6D6bjq15TPyPDiVTiIcLQJA4cc7S3ar+zkb51cS9XUcx9CMA8MVj1OEhEztS7FGh3AGx0hsVgjpY32DKDQygucQdTJz7OBifRTukqVl1ZmtJu6nHHJbaVA6JaxtcPVcGwFjb9Ct7Gl774BzUiX2e7U8YZiEjjXui2Qdi5mwqh3jI0BcQzzsVYKyMeSLsXfFsPWWwY3r7j/O+2862DoP3Fj061bMRkBo2UssjaxUgfnV39v6l9h+X8pW1mB88YfoSZBZWc4oYTdzMZZ8dbJlCpJYoSYhXal8O5VypJFmvDADxn72CeFmNpZVqNASXxmA88We+U8kne89+LLE9IKYSoHjb7LmFRBtVgTPoeD8Hv1V+b8e7XTdXxtx0AigHh06qkAqF+cLGPnIgrGt6bvCcEYH4jaa4xrnVeH00g+Iw1h3nWIA5OHR6IROh+NWhHFMVYoVwMN6yn6vcHGe676vgfnXPtA/FwwQg2bppBJM+NjVlXSBSCmWr8kXX2q8IWfkkj3BjKd75ZxB+VaV9KNkFifOr3kr+QSqZBCKNoHjTtlL5YrEyxL4CpcTHIFgliwpxy6D4ZJMphd/I8lBcqybjQ1QyC0TaS7SAkcatub9mIDfB4z0ZYMQv61UGwDuVnORA/IYUC0wOO67bzNoiIJLusrWBkVo53NprV8+JxvLuxbofL1PdSm2ZwTtoKh03wal61ypjQyV+ESdtMRAsSM/nP1I5MXBW6pfHWCb53Rh2NGwvbEtJj8+rXKgk8EuVELupv7+RlvclBwOJNgHIw4vqsDX334u5x+c0MXGTrB2Kr6XQCfuUwFuHSXswkGhJaHmmjy61PMFg4wzYO9lBDRhQ/LkVn0/R03g+enqF9KyTc+LWk/Cp9rvcuJRICFHBHIr/Dp2vq2S7JGyeDAhmYCir67qNVYQBxvmPz3miShzKFESS6/MpJFpo8jz7RyBx7hPnO64q+hyfUMYFJm8JZu2nAZG6UFheYP7jj2/yLNmNymBdJYCk8ri7QgiZRXlkNfXhE5pXnmwh258nyx52iUAciquDkLlTR62CXfvpQGpOcSARCt0nbT4Py3nnKbXQQV1ZZYohMxs2Px2INOpddhrPXrP5Ca2+t/lRJa4U72G8052FIT0TkGquFJ/FxvkPLX+cBMaS7WB4TQ5ZpA7pGYFY6Hj4MMdh/sM2m/dIYyje7nv+OP6QMYudawQDiDj3IWRwh+IgDlKH9PxApP3Qcff5j4PDBu2DWdnrTBnHVWU65kl2yjMbku1iRUQ7FiA9WzKwXbLtwZu1YwESr26M/578sxy0tdeZuiZhHQOQHozMfd8sGccE7FAW2TEAkfowehUjgljbNlannlJSOxYg0n61cBCxfGZAuE8ToRykkp86200shkvMH7zGPE94dxsbuXh7YzGU5wYijZNkVlWyPKG6jTer4m0O9l8EQzoOIG6xasR2nrkOq2C9G1WuElfI7M3vYwCysy1K8PmMz4C5N7Oqn/vzrjwuHm+TohDZtmvPDSTCiEsBrI18U7vxfaMG5FL7fwuc/XHjLxcyniOA4Q/6AeNWZVVsUFPIF5U/bPxc9/U/ONwLmTk7BiCxfPLsyaXKAF/U/VDEmQqQtQoQ/8tPgLDKNgqZufwhHQ8Qzx2ECs+6DyqDulJ7PhYg7MffB7tCPKn+GiETniogXE5Urjz9x0YF0jeNb0VEeKzUO5BsUWnSnhWI2VZNCbdqTdpWZWA8V88zI9I438SFae9DdtKyPy+TjgCIqYQ8cveR2qCvNb61wP7kHG/O9p4NWQpDOgIgZuQR/9mBAMPnM3Si5IvYsi/OHdiD/sHsY1q9gRTnM701UqkB9JZ+b+5yiDqkIwIiye+qASXbxhmvg3GVHQxDOjIgmKlFGs+EpTEQth4a9wKBHSUQLNyHzWbCkuWIh4DAjhpIZkB6jMFn9ssBeWo7piXEo7D/AbzDm4IuO2E0AAAAAElFTkSuQmCC"
+         id="image34" />
+      <path
+         class="cls-5"
+         d="M240.07,437.73c-8.72-8-21.88-10.93-32.49-4.7-10,5.91-14,18.19-10.22,29a5.93,5.93,0,0,0,5.48,4.18c14.38.76,27.09,14.5,22.22,29.59-2.26,7,8.71,10,11,3,7.16-22.17-11.32-42.81-33.18-44l5.49,4.17c-2.12-6.08-.9-12.69,5-16.18,6.1-3.61,13.74-1.66,18.71,2.92,5.37,5,13.43-3.07,8-8Z"
+         transform="translate(-112 -195)"
+         id="path36" />
+      <image
+         class="cls-6"
+         width="162"
+         height="88"
+         transform="translate(126.18 76.18)"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKIAAABYCAYAAAB2+yxkAAAACXBIWXMAAAsSAAALEgHS3X78AAAXIklEQVR4Xu2daVfbWBZFj4GEQOaQoVJD9///Wd1VSXVlhhDCGPcHafudd3Ul22DAEN+13hIIx2Bp69xRymg8Hmtl89loNBoN/Xy8Oqhz22h1zBrrgatv38i+dhvbNjuwnX0raBv76UAMwDlQEa4IGa9Za9dI9b8b2/rRrgzIcbKN+346QG81iAl0fSuDyyGTvWZd0ka7ZZ9U4DuTdNpu2YeNkxWhzVbzj2/xybpVIA6Atzaw1pXDFVVyrX3NHVu8XioQntg6VYFM6sLn0Dq42arAvG1Q3ngQDb4+8Bw0X+y7E9aGcnVcb39+V9Jmu+V9pALVsaSjdnvS7s9U8FQ1tIDL+/g6UxfWWwXljQQxgS9Cl0HmAN1N9m/a/nXVEPLed3peKxU1BMQjFRCjomWvBVz2O9DH9nOH89ZAeaNAbAHM4EPlAMvh2pR0T9JWu2XF17HPXW4EccP+Da911+xwHasGxtXQQTxUDSP7WN/b5fsimDceyqUH0dQPMKLiAZRDtmVr27Z8DXSbqmHsU0T/vfPEiLjT6Jr7FJEtAB6065ttv6mG09U0hfImALm0ICbq5/BFpduWdL9d8eu47qnrot1VA1yWrGRZM69xtcuA4DWA6NAe2xYgD1WDuC/pq22B8kDDUE4UeZmBXDoQDUCP+YAExQO2B+16GLYRQnfLrnyetGQlmRiLxrDAYXXXm5VjZNuYNXuS4krpyugw7rVb1jfVauku3NWZv2/p3PbSgJgACHyon8P3UNJjSY9sZRACHsszY4fOV1RCt/iz+PMIXTy48WdZmSYC6a4aGAEyg3LflqulA7l0bvvaQewBkJhvS8XNPlQD3GNJT9r1uN3vEKJ+UfmAzwHMwIpwZTbtNbMc1EwtHc7MfWcKGaHck7TbLiDdVwGSJIoa51K47WsDcQBAYj6U75EKdA4givhA3SQkxnvEfLE+6JbBtaiDMw+4Dmjmwmdx27uSvkj63K5dFRd+oBJPAvm1A3nlICYAbqgkHrheoHtqCwBxxSigl2OyWC+Cl7nTaNNc7Kw2zZUPAZopJSo5BOW+Ghi/SPqkAuMXFSD3VUNZlZquA8YrBbGFMNbkcL/EfU8kPZO0026ftfs8DozZb3S7s4CXwZapUdw/i43Cyi6KPkj74Ix/Wwalx5Jf1VXGL2Hhuh3IScnpKoG8EhBNBYGF2h0AOny+UMJH6sZ/xH6A3XcyM9gAzDPJvqQhK8NMM4cvlnuy5GgI1GkXUoQSlcRlA6RD+UnSx3bhukluOh2hqwDyUkHsiQM31QCFAj6T9FzSi3b7XEUFH6tWQHe/fvJk22ngRSWJvVzPWvsK00MWLzovgLtys7yEtGb7Z8nk42fNgPRs+6uKy/4g6X27AJI48nv7b6vO0GUCeWkgBhX0ROS+GsCeqlG9F5Jetut5u59s2AHMWm998MXM08HLerkn4efTWnVD5hde1hL0LD4W0yO0nnD1qaZbBuSJ6gL5vgqM7yW9a7cf2n2e2HxXOT6X6q4vBUSLBTkRJCJkwDtqoANA1PCpGgBJQjbVX2geclFnqhXNW2ke3FP49Qwyghpd1SwWPUA2bOE/i8vrn31VAFdMqauUfkH6BfhdDYy7alTQlfGDGnX8pAZWgPSE5lKSmY1pL5jHggqSDW+rxIEoYFTBZ6rdMADiruKVjzL5gY6ZJMD54ID3bw9sX5x+iYronYlZLHqCCJTv91altyxjVyh7jyxMictDBH6nd6cIkbxC4VACJPHj6Wg0Wrg6LgxEgxCXck+lFPNMDXyv2oUKekbsbpiDl7meCF9fSywbFjhIlitidM8ntn8Wt4y5R8hcrrtlwIh9c8pT3imKE0RZ3TQLXVxBY8hAzdZLZpTJSBA3VRIaujSno9FoYa3ChYCYuGJU8KkaxXsl6Zd2uQr6h/UyDO4Gc9friuWKB2ze4oo1s0wJYxwY40pc8qxuGYsnPktSgNGB9G4SvfT7UxawxFja3TbnKMawDiMNhFir5f3vqKjjSA2MC3HVFwZxNBrxgYl5iAWfqYHuF0m/tttXatzzE5VkJEtEMADsq5WxvoblrS2fUHH4PC5E8bxME7+f92D7yXfX6d87kK6QjLC5IjqYDgyJHa+bpbrAsY7qGAdKHHRX3w01x/VI0kkL47wXamXnBjHJirdUJB4VfK0GwtdqoNxpf04ywgGbBUDvHHgri55q30SK91g9DnQFdNgcuvMAGM1dZIzfHMi+WA6VBEwf+sCVetcpAhk9TQakhwuuzD7PmdVw6WGftG763DCeC8TQIaEs81AlFkQFUcKXKq6YZOSOavchdV2wAwh8sVMQm/uugNkolLvaqHYVdItwOdLkeFW7bBvBnOa63Y16GzTrQGVqlsWR/vuH4tcII3H8d0nH7cc8VxIzN4ghHiS+wBWjgr+pQOhlGWKNeHVmAB6quN09FfgoL1Bi2FN35Clmuw5fVL2FAddnyftPvjdIfZsppbtQlAr3nPXkWYCJsgGku+yRfd13MXiC5Kro73Ms6ew8ceNcIPbEg4/VuNxXagB0CIkHH6j5AH5FYgASFRDXG1tSQIgSeifAi9MRPrGd9yBdptnfMpYmYP5Qc2JP1QXTgdxTcw4+qZ5SAkh69Z4JxziyTx1x3Zkye6zoiZGXeOaCcWYQWwhjPPhEJR50CF+1+4lZqAsi5VKtglEBqfwDH1X/T2rAdBX0rNeTjonqzXNArtscTFNLYq811R6DmNmnbUhkcNfPbVGvHUoUR8nXEcgNW66evM/cScxMIBqExIN8UM+Kf1PjlsmMH6nfFUcVJAb8ogIeRVUgBEDKB53xJZn63ST4+ixRy7HqzhEJGFWEPRWR4EL2WPqrylRTLJ0BpFTOE8IRFZkty5Oijfb3jDRHEjMVxADhtmpXDIC4YorUxIN3VbviPhXcVd37ZH1QPdhJHOgKyHveCviGzD7fmblwoDxSPQLmVQVP6vAmuGxvqfr5isroQGYqCcwefx6oUfapCcwgiD0QPldJSP5ot7hi4sEt1VmV1ABDkfhIRQVJQN5J+p+kf1RDSCkGAElAfuicGdptsPZzj1uVpNQFkBT66SplJa+X7c/ItnHXHkZJw0ACIq1KVNE9H3/nYMzYC2IPhC/UQPhHu35XyYypD3ppxv8grtxDlab7JzXQ/aMaQnqcHgd6DPjTAhjNgEQhOdbed/ca7J4tSl4ke/T7Y2LprvquuslMVEOpeCrWYAKTgmglGhITV8I/JP1bDYSvVSD0q4k/lISBg+Iq+EEFwL/br30UiakPz4JXAPYYx2U0GvnJj0CikN59co9Dt8mTGTJrqcCXZdWuoq7Q3qefJJDROiAmED5SExM6hH+oiQsdwr54EHdBMI0KAqBD2Jn0UOuGVwDOZgFIj8m9RQqQuO2sAXCq3MM5jB4vopqeSMVS2rgvealAbCEctfupEz5VKc/gjn9V46YjhDEePFEJoL+oqODfkt6quOOPqqc7jrWKAy9kSQzpKgWQuGzf+jTSmUpm7TE/ELr3k4r3Q3ziQAkwds5pVERoz+LC35W74z4IKSvQFUEF36oo4Xs1EO6pqCAHYAXgAmwGIAEGCCOMVCa8CiLVSYxUi4+/b1TGNHmZgJio4QOVCZpfVbfsZoGQ7shHFTf8RkUJ36tkxQdaqeCl2ng8HifuGpftCpa1SD2283PurnpTOeTUOk/s/eJ7dhQxiw1fqR7hyiAcqa4PHqhxtR/UQPdXu9603xMP4oonJZkVgJdnQR1ZDmOmZKionxfPnKXiphGwLGuPMegPd9EOImTfUV24fqnGPWcQemJCfHCoRuU+qlHBPyX9Vw2IQEhW7AnJSgWvyII6ukICJMszXk9OfHnMiIihjEBIUsR01GF47wZEc8trKm08JqxZNMwjhFLXJX9R43rfqgHxz/ZrIPSseKWC12A9saO7bNynCxSLUo27Z6mGERC9c+aluSOZZYq4oaag6UOYdEuyupJL/Ilqt+yFatzxN1k8uILwes3UkaTE3TCJ65a6tyZ44oLBhQ/G+DgaxfIJyKPWP0cQHca76s6fZVeByzudE2qGX1T6nBRNV/Hgkllw1VKJ+e6pTFnFJoO7dniICuqzkwzAoKjOUOVeMVz0uq0YD2Q2FGvETGkF4JIZrlrdc5hlvTF5wUZhOUeoYMpRBqL/MSzPnPog8l/MRIaPmntT3Es+K1se83NI6y5O1jhM0cZhxTKRQ1xx5K7ZYz1vB8VKu79JpP+OajnfUZMpHdm/ndjoAvc4rGxxZskqMSHn8LHqe50ZF4stP6mcWxiiNuldm1gkn5z3CCIQEucxPsSExpaKf19XDSQf4r6aP56a0Q/7ubt6xrrOdY/DyhZjNlvA+Yulu9cqY36U77IRP6ko4Ima8/tV9Z2W1I07JbsNtd9ZGk9rjikZ1kOVjIerwbNnXPK2igRLdfJDoIp7poxzRrC8AvLqzCCkGM0NWT7u57MFT5R31KRuQ4MBF6btP6m0chGoiWWK6CUYBlbjvSceI7h7vqOuSnq86LEGMK7LXP9ogY+xWFluwRUDITfCPVfTSftd0r9U5gt2VIsR7+EhXeyqMeBC+W5PpXJSJTwOolRKMAwrfFR5ugDpt4OYNcHv2teA6EGvQ3lXydTNSh0vz4IrjjE9EP6mBsDfNDzkMgQhswW0dRlumXRV/PxOQDT3TEV8X42cbqlA6F0VFDH2nPmakg+u2IEkm95Syai5WlbqeAkWumfrKjU+Omgv1L0R7heVG+FmGXLZVemo/aWmo/ZGjSJ+Vt3M6M2ape4bE9t5fOc1RSzCCIAOJFcgEG7bAnQPaFfquCALKhjjwR2VmPC16qdz0Nr1Tso0CH2+4M/2+09qco5JMTyezwrEVhWluk/oyUVUQ7fMTTuYwIk72Fb9YKH7aiR9U8mU9iqznt+SWJBjHx+MgBJ6hvxE+VCsNB+EzBdMYsPsPEZF9HYPsWKEKkI4tpW57ui2uSK9nw2IKGR638roEh4QeRstuGGEBBX0eJDyDG74pep7nmnJ+fmcBuF/VIZc3qsMuRxLOhv33OPcAVHqhVHKIfTJDb+BKpZ23D3EPqQD+UDFXad38q3cdW5JHEhMztAC8eBzlYemMmv6XOU+5+zGKalboiExeataCeeCUOoBUZLG4/GP1k0f971E+ejQD+U33KzZPj9IABlhRCWze5sBkr/hp05qpgC4rfrxxCjhK9VP7u27lVQq5/pMjSDE7PgvXQBCaQBEaRBGT9vpxvgwJeUePpDUddXEnMQtro48v+WR8qc9+KTvmdRM++onUskWPqlc7LjgCGD2HJwXqh8dnd1cH11xnC/8oDJ9/6dKTDg3hNIUEKWpMHpf2sfLUUbPtmKc6dk0B5Ak5oHK01Cfqvv8G9w18eNkwuc2q6TBN+34RQCBcEfl2TcASP84i++9ZXeo5rj73ZhvVEo0npjMBaE0A4hSCiMnGyU8Un3TzalKPzHGG4Ao1epIVkdQ7e7kmeongtG7xF3HwQxUkoMwlm4mmAE+B9AV0BORCKDD91T14+kQCkKmzBUTD/qDEf6nxgW/abf/qNwSPDeE0owgSh0Y3TW7Iroq4qZPVWdg7qozdXQYH6jAuKP8IZ0MZaCQfjGgzD+k6qYhScsJZgCPbVS/LL7Gg/QB+EhdBfRYcMgVxwcjvFW5G/OdiqeaDLLMA6E0B4hSBWME0QcoHUoHk0A4c9VSVx05yPEq90EMpr+JH/3mHBSyUkl1wZSuUTF7wIvwxeTOY2qOjz+Yc0f1vUbEgK6AEUCp3xV/VP1ghL9V+se7smdp6xwQSnOCKE1gBETPmj1hAcZDW0eqg+LoDoAwZn4e93DF79ry2xEcSE9qokpHMMfqKmYF5UUgNdgmu2zb5xk4Bn4cYrmLWNDnBp+qfpa2A4g7jwB64nmsevrKXfHf7XqnMk3DjVAUq+eGUDoHiJL6brhxGI9UBiJZxHI+YBljR6kLpGeCuKAnyh+1lrlr7ql1lY6hA39/BaYtBUjnMVf9IfA87gM+B/C+SkWBRWXBb1DiZrdZAXQVpDSzpwZCCtUo4T/KH4zQGWKY184FolTBGNURGA+V39P6XdP/n5V4svzk4K4fqzkQPsC7pxpEYPSLASi9BBTVsnLhyfezHPAI21ryvcd8Uf2GFPBhWPdtMUgyBKBUiwcquK/hB2V9VPfBCKfSxctm5wZRmrgr+tMxbuRkOywOpLeS/ModAnJdeZCO+n7rWQfJ8mybWBYw3X17rdQhnWYRtvWwovJtqhv/RQhjsd/B8wSkLwaUum6Yc7SnEg++U/eZldEVczwuDKF0QRCxJG50qXdV/GprX/X/DbKt3F3HFYN3jyEPw/puK0JIDAmQnnG72z5RVzVRxj6LSu4rul/gA0A+j7vjbdvys3uqh41d/foAxGMhFAdqzsOuyqOj36vA917dxwUuxBVHWwiIUuWqT9SVfa46YCSme6nZ/3dSj7WyGBKVdGhiBu/gOYCZOmbv4wX7aSDGTNfVyve7CkYgt8J+Xu9uN8I3C4CHasTBE5L3Ks8uf6/yIHhUcKGuONrCQJQmMErlRGUJDHGIZ757yv+/5hg/rrW/akglN9V1qbHE5MAdJStCeBx+hovuMy4S/h7giTBuJuuuhv+Nu/cI30jlAokVDQ+VEAMgjADihokFF+6Koy0URKmKGz3Ij1kZV6MD6TC6OmaB95BKjtvX8fs9JnIwM7fb55ZdET1WzE6Ix7Ou1g5UdM997jvGlpnysfXP68fcPRLH/LPKjU2oIZ0rSmAkdZNw5DIAxBYOIjagjpmrBsjPKjASO3pATv0RINfVPSl+YtbVD6aXbICrL0lxWNlPTBwtU2kHLEta2PKZ/LNlF51/Ro/N3QXH40x565PKf6TEolPFlBMX3eSzXiaE0iWCKPWqY3TVqCMB80fVjflYG/Mg3U9sn1J4zMRJ21B+Ev1rXw6pv7bPAChmzWvJGoWv45Lyz8Dyi4nj6qUzsuHPqsGjFIMCxjG7M12yCrqNruj3SFJ27wR1QQq1tPJ8PVEp1j5SKV14ySK6sUxFMhvbNn7dB6qvPoswzQKa/53xb45/GxeHexmPAd3ToILAR3uU1py3RKuw46oglK4YRGkCYwSSzNF7p3RQaF/xNVB69yCq5CxK2WfxgGSQzmpDsLEvmr9/djF4nIv7JQsmESTUQQm9N0/BnzKWVwKuHEDsykHEEiC9LhhbWt5PBUi6CijkNCiHFEnh68wucqD63rsPugw+kg9PQKiHxkqE99/72p5LASB2bSBiPUB6aSN2F9xNe7vLOw4OpZeAYvaZqWWmXIu2IehiEhVLT7F1SoMgAgh8dJeolS4VgNi1g4glQDqUxIMOJWCyMigBMutATEsgZnXls1oW5/Vl7rGk5IX3vv46iujjcAfq1kaXCkBsaUDEDMgYR7pKRveNC3coXSGjy441PX5HhFNaPIhePcjqlbGA7gBGCH3r8AFuLDktHYDY0oGI2QwfCuV1N2+R+ZCAQxldtbfOvHMBkHFggDqedHEYXQ093sugY9vXK/9mW76OLUqK0BP4tKQAYksLoluiklEpI5SoZRwS6OvbxrYaMC4yXsQlO4QRusOe770/Hl8HzA4fBfcfki401HtVdiNAxMJY/RCUZN+bqqGL30cIs/72IkEkJsxiP752ZfR+uG9jKzIW2pda/TK7USC6zQAlYMZ1N2xdUYcU8bxAxiQlU0SHzkFjeTx5ZisW2m+E+mV2Y0F0G4ASMB3QmJhkwNL3vQwQvR0HkBE6smfPqn2NdQvgc7sVILolUGbxZVyeCHnWfBkxYuyQDEE3TlbzZrfsxN06EKMFMNkOQZr9bBGWQTUEHf/m1kGX2a0HMTODU+oCGvct0sbJ9qeDLrOfEsQ+C4BOdif7zmOdA/2zQpfZCsSVLYWtaWUrWwL7P4apN4zN/SW1AAAAAElFTkSuQmCC"
+         id="image38" />
+      <path
+         class="cls-5"
+         d="M383,310.59c-27.19,34.28-80.61,37.58-114.78,12.53a69.72,69.72,0,0,1-13.32-12.53v8c27.18-34.28,80.61-37.58,114.77-12.53A69.48,69.48,0,0,1,383,318.63c4.54,5.73,12.53-2.36,8-8-11.07-14-28.42-23.95-45.32-28.8-27.82-8-58.86-2.9-82.44,13.93-6,4.26-11.83,9.1-16.41,14.87a5.94,5.94,0,0,0,0,8c11.08,14,28.43,23.95,45.33,28.8,27.81,8,58.86,2.9,82.43-13.93,6-4.26,11.84-9.1,16.41-14.87S387.55,304.86,383,310.59Z"
+         transform="translate(-112 -195)"
+         id="path40" />
+      <image
+         class="cls-6"
+         width="293"
+         height="173"
+         transform="translate(61.18 22.18)"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASUAAACtCAYAAAD282l2AAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4Xu2de3fTyPK1t4AA4RJIAgwzc875ff+P9c6ZgQMkkEDCJSHR+0dru3eXqiXZsR0n1F6rl3yLI9vqR7uqq1tN27YIhUKhTdG9sReEbpaapmm8h+V27yzUbsiZ6Sbve2h5auI3vbkynbiRBmerap1tK/dX3tlv8r6HVquA0g2TdGbtyHekNbK1nR0oO3EL4FK2l3J/1tGX1clv8r6H1qeA0g1R16FtR74r7V7XeFs7utex2Yl/ArjotrzNVnT0RTv4Juw7EIC6KQoobbikQ2tHZifeAnBf2oNuu4XcuYc69k8A5wDOAPzotmzn6Hf2S8wBpw3a96XANbQeBZQ2VE6H3kLuyA+ROvF2d3tbbvM5dv5ax2an/QHge9e+dY23+Rw7+jkmwGkD9p3NQmohuIbWq4DShqnSodmZtwE8AvAYwJNuy/aoa9tIHXur+3s6DopO4wKps/5A6sxfu3Yq7aTbfkXu8GfIUCjyN8gQaZDBsu5918+g+62QUgcVcNowBZQ2RAMwYmd+AuApgB0Az7rt065px17UbWjH/tK1zwCOu+0XJEh9RQmnC5RQYohGGK1730+Q95VbNr7uR9f4PpcBps1RQGkD1AHpDnJnfIDUQekqngF43rXdrj1D6tRPkF0GOzXzMneRO3WDDI8WOUFMx8EQ6Ctyhz4G8KlrR137jNzB2bEvu/flZ3iADKMdrHffFUyfkcF6LPe/dK/7jvwZLhCuaSMUxZPXKHFHdBcKo6fInXkPwH633e0e20Hu1A+RE8YMfRj+AH23AeQwiKEQQxs6jxOkDnyEBKWP0o6ROjbBdNG9511kID1Fgs+etHXs+zf0waRw5WcgYAmncwA/m6aJUbprVkDpmiRA4kgUYURnQRC96Lb7yJ2aYY/mYGyH1tDH69gMhWwH11wNQ7kamE661/3s3vMe0j7R3XlAWvW+K5wI12Okz3AI4ADpO/6A9J0fIQO2QQJThHPXqIDSNciEa/eRncVzJPi8BPCq275A6tTPkTo6HQaH0Bnq2Noe7cw1aaKaw+YMjc6Qc0AKSToOuqVv3WuBnAOjS2K4Zt3Rqved+0847SG5IsLRfo8MGU+RgHzegYlhaWiNCiitWU3TsANuIXUIuqM9JBD9BuA1MpT2kHMwGu6wQzP34jmLoc7dyvMt0vuwk1+gHDVjOEn3w9wMndJ59z5byE5pBzmhbUO1Ve474cQkO+GqTRPsNpc1+0xdKBdgWrMCSmtUBySOrD1E7ugvkGD0e9deIwNpB6kD6ciU16GB4Y5sZf9OO7om3QlPwmkHyW2cItcyafimr9Uk9hCMgOXuOyGlcCWktGmNlJYiNOgcYIBp/QoorUkSsm0hh2t7SPAhjP7oti+ROv4OcohBSAzlXK4i+z78H0zCa4nCE+QqahZUAmUpg1Zo27qjdew7UMKVoTL3jYMK23LfVpMDAaa1K6C0Bhkg0SHtIzmiP7v2B7JD2u1es43sMObNuVxFCg26EDoQdupHGK5T4naRfNFVVIMr999CViHF/bbvEWBaowJKK5YZZXuA7JBeA/h31/6F5JBeICWFnyDBq+YwhqSjRkMjSPpeQ+/L/9si7YfmcIoJr/LaO2YLDP8P1ZT9n2ffKQ0ZCSjCSWujLJRmCfWmaaKOaQ0KKK1eBNJ9pDzLMyQ39CcSkP4PySW97J57jPKs7dXrWLXOVptVY5rmZGr/x3ZwhZP3urH3U82z/4vuO6FKKLHdlaYQ5f9W8LZRLrB6BZRWqM4lMc/yCClH9ALJFf2J5JD+QBpp20WZP5riMrQTX1aa7djqFrymr/Ok+6RA8F4zpnn3/yr7ro8x12TfS4HE+ie72gBH5QJMK1JAaUUytUjMI+0hj7LZpDYd0pRwTV0EO+9Pabp0B5+n2AF1dE2TwdpBh/YBI88Nad79Vyhddd/5mIZz+jruE/fDrjLAkoOA0ooUUFqBnDzSEyTwvEIG0msk1/QMfYcE+B3KdmYtdGSx4A/ZsjOxY2un5lD/Q9kOjZYtCiBKXZHuv63Eru0/sLx9b5DDOXR/S+l+6dIo3J8LIPJLq1RAaTVqkEeqHiHXIr1G6ZCeo++Q+PcqG+bQRehkVF1yRJfsmHUk5P3iKKAuJ8Jm64o0lOR+TQWUdlrCSMMiO1+ttv8Kpan7PgYnD0wKS9037otO3r2MMG41CigtWZXhf4ZtBBJzSE8w7pB40DPMoavQuWk6G56V1pxoeoY+lFhQyFUI7JIiWoFtk+53UIZTniyMuO8WRroiwdD+K5Sm7LstNtXvFyjhasHEUgfdRwUll2yJMG5FCigtX9rxHyO5oZdILonTR/aQOtBD+E6EUiAxpPiOcgY/J8jaOWlc92jIKelsfl1ahHPVvKktBBMwvM8KI7q7MyS34a1CwOVRavsPTNt3XRqF7onOSaHqgUl/N37X3Fe6uOI7jTBu+QooLVEmuc2JqfvI89l+6+7vdM/rtIYxINEdfUHqwAcA3iPNdj9AmgGv6x3ZcINifQ5zMVyAjZNutXESsM7qt65J913zRQojz915Kw9wxr7df5tTGtp3rqrA/edE4Bbp++b71MCkeUCulmAXitP8kibiQ0tQQGm5ohN5gOySXiC5o1dInUUT25pHUnlA+ooEnEMA7wC87do7JCh9Ql4fiGGGuiR2QnVLnDbCcoUD5M6ty6VwVr0NibS+B8j7a/NGuhSKuiO7FMpnlGGS7j8wbd8/Iq+y8Ao5fL1Edk2ADyagdGNPkeB4inIlywJM4ZaWq4DSkjSQS2IHYbX2lMQ20AfSMVLHewvgn669QXJLH5E7NPMwWg6gHYb7SVfAaRYWFoco13DiPDydvKpzxYDSGdEd0SF9xfTVLGv7P7bvbHYROltaoGBSKZh0kIJuibm7ofcOXVEBpeVJc0k8ezOceIGc2J6SR2IIdI7UIT4jAekNgL8B/IUEpf8hwYNAKkaHkMMeT3fQXxRNE+eEE0M45mg44/6+NIXSmbQfKF0SOzZdkToPhenY/tf2Xd2Ml+gH8neu3739DTzHe4K8WBzDTH7n4ZaWqIDSEuS4JNYlceVITrB9hNSJ7ZQGygLpO9LBf4jkkP4G8P8A/Le7f4DUUeyo0CWAweHqpmla5DCLzoYAoas5Qh7ReoJymQ825sUg70UYEUxMGGvSWIf9ue8/kT9/df8H9p2A+o6+YwRKp9XIff0deJtuTH/PF8iwJpi+I9zSUhVQWo4017GNvOaQ5mR0TpuXR6Ja5BqkE6QO8A7JGf2FBKQ3SAnuY6TOrXmTSbUz8pqLDqq1pPRnlDC6b5oHJTolva1Fkd/l+SJhfIV91zwW39cmyZnk11zYFsrcEpBhpb+pTagfIIHpFJ1DbTq7hNCVFFC6oqR6W+0+ocQRoHnCNs0jHSHBh2Hb30gOiUA6hYQni3aI7u/azoGwg9N9fEXOHzGHdM/cVijR8RAKF3L7XJ4nRCbDyFNl3+2omM1BEajcd+/30L+zv+vzrjGX9w3psw2Fy6GJCigtRzZ0Y92MJojZCWodgEDSsI0u6Q1yDokh2wxI7ZLW+RmAk5YA3JUtGz+PhlWaF7p07re4Aoys2rZtm6aZvS/KHBKBxPomrjqptVeeWwLK0TgWa2ot1DaSo72L/DlDV1BA6erybD4L+naQk8Ms3qsBSV3SKbJLeosEJQ79FyHbsoCkqsBJk8J3zFahxL9pB9qkEHNeyX4D6fuxub7HSL8Pa5cIpiG3RBfMAQzv9/2CCOGWpoDSFSShmx70OyhHrDS57R30QO7IHG2jS3qPBKP3WBOQVOzkwOyzUk1l21a2K4FQTW3bXgqYviF9b3Q6z1Dm+fSEUXNLNunN9yCYbAi3ts96GxVQupo0NGAZAEM3LThcNJf0Dn2H9KN77VoPfAOV2W0Dq7XCZ0T2O/2MBHoWWe4iOx0dEfWkOanHyFDyEt5RHnBFDY0ChQbU9K9MwlwSD3ieiTVv4Uld0nfkzvMB2SEVBz2AjVn9sDUae/261O0LRxR/IH1/xyjnCvK6depw7GfgiYRhIEN0QmkPzuiqhXVougJKC6jpX7tNgcQyACZBNZc05pI4BH+IBCNOH+FcsJ/YICBturrviSOCnMhMMH1COWCg5QOe7GAG65ZeIF8KqwjVA0yLKcK3OWSG/3U6yXPkK9sqlDRfUZO6pBOkzkIo8Wz+Ff15YKFpapHn4DGMO0KG0gmS09ETCNDPLWnCmyEcf3O+jxZSAinxvUkh7Y1QQGlAcqZrpLFG5wHK+W2/Ic9x46TboZEduiSb4NaJqjyTz+ZYxQE+n9q25Sgiwa+Tgo+Roa+5Jc/haAincxtfde/BaS2sSm+Qc0yEVAtsVN5tIxVQMqqAiPkjrXdhyPYS+bptujTJWBkAkHMeDN2OkaFkz74XcTAvLK25IvyPkScDnyJBhjkh7ySibknnxL1CufYTgcTjxU7/ISQDUBUFlOCCSAsFeXDRHW0jA2kfeUXJf3W3d1GuBDDmkmy+g7PnOcmWB3UcvFeTDZMZwvG73kEZwhEuKh4b95CnE3EKDcGjboqJdE6p6RWWdoACAlIz/bJQGgERp09wbhcXFdPiOYZtr5Bg9Ft33x7cNZekCW5d1kPP3rOzbxysi0tCuAvkkThdCWEf5bIyY26Jx8YT5EQ6IabJ8CMkAH5DnqBMQNmpNuGiOv1SUJoAoi3keVFcomO7a4+RC+fokrgKAJPbXt2LByXNJdXyHByq5kEbupoIJS9/9wnl4ERt6gmQjxtO5GUpgYZ2HJ3TE4yuisCJyYSUAsq6qF8OULceSnOAiG5IIaTtCcopBlokSRjZ+VSeeKDVRoR4dqVLCiAtQZ1b8kK4w66x3kgvd6XHDsXbWrdk7+8gnaiOkRewI5hO0YeU56IIqgJQvwKcbiWUFgSRXq6HawjpWkL6+I48b1djVIc0NZd0hHzG5pl1Vrn9KxyIa5INmVmzxFU2n6Oswqf78cSTzn2UuaaHyAv8naC86MCpPKaPf0Ppori0Sy/Ua/J8xFvrnm4VlKSOaFEQse0gA4jP6+xygughyjWF+D8BH0hAvcr4EBlKGrrdygPvOmTcEpe4pVs6QA7BbU7QhuEN0u+ivzWhxJG5Z8iw4cJ5dEoemMac1A+UgLq17ulWQElg5I2YzQsi6450gTNdi2er+x/WGdVySEAemuY6RZxSwhBCq7fPEXVJq5C6JZ4UDpEvz8TKbF2QrxbGEUz83bWo9hzZ6XCEjitjEj4KIcLqi9lq6EcXdQ4Zzbtt7unGQklCNB4UPCAIIk1Ua25oCojoiNQJKYTUFQ3BCOgDSWeuHyLPcTtEfyXJG3+AbZqc3BJXZPiAMj9o68zuop/41tt6TGg9G5PXBIkCSiGlLuoL8kUKPiMPfiigbq17unFQckI0hZG6oSfS5gURHRFLAyyEamdPKw9IzGUcIi9N8gGpY3DN53BJqxXdEkPoI6TwbQfloIXNEd5BfUSO4utbpGOHLobHgALKc1EKJi0T4cgsE+cnGHZPl7ihcLoxUKqEaBZGBNAO0lmPZ75FQeQlrafACPCBxHDhAGkVyTdIi7i9R38lgBt3MN0UiVv6iVwecIg8ymqhxN+axwPg//56bPD3a5FdFgH1AGUJgAJK3dMJslOycBpzT+e4oXDaeCg5MCKINE/EsIzr3OwiL7Rmk9bzgqhm14ekB6B1SB9QXrvtLRKkmOCOOW7rkc0tHSG77G3k0VRCqEVZ7jEEJ32cgOL9IRfFUgDCiTVshBMBdYS+e+L8O47mcQTvxsFpY6FUgRHjdC1mpDNi3dAu+pdsXgeIgNId8UysQDpAgtB/u/YPUvjGBHdMKVmTKrklHl9a3gFkaDxGToCrawKGjxN7PA25qAvk2QNnSMf3d2TnxHyT555YrEkHxRG8GwWnjYPSAIw0V6QgYjGjdUhPUY6erRpEvK1nPZ3SwJDtb2QovUXkkq5T6pa+IieoeYwA/RyQJsH5Onu8jB0/Qy6KkLpAnmt5jjybQBPi1j19kqaAulFw2hgoOTBizcdDZFdkAaQQYiOMOKyrB9mqQMSmOQJabzqkd0jO6G+UYdsxZPXDTTxIbqs6twTkE8gJSsjwt/yBXG/EAkuGeHps2WMKzn2r2us1zGNZy0+kY3sHZd6J7olFuFr3xtq3GwOnjYBSBySFEZ2R5oqeI6/suIcyRNOcEQ8WC6OrgMhCiFt1RnRHHPI/QQbSe6SkNhPb7+CUALQrvhBAqC8TxvE4BNJvS1hxVIwOZRf55Dd24lMnNHa8eYAinGwKg1EDAUVHvo+8UOAhyuV/bwScrhVK4o74Y/KMQBgpiLTRIXH4lhXWtqjRO3uNHRhUzQ0RRLXkJEdz7LA/YfQBZeV2AOmaZcD0FeUAheZzGCq9QHn81VIEWkYy70nRPsf30xP3A5S5J82tst94cDpGHrVjxfhPbAicrgVKlbwR42c6oz2kH/8lyrWQGa4xgW0PBnsgAMM/PjUGIQ3PasO4PJMeI185433XWIvEof/ZVJIA0vWrzZdl0t9cnS+dCHM33rHoFdzeleYdm9RUQNXcE/uPHYn24HSIckUKHo/qnK6tOrxZ9/817kiT2I+Rv8h95LWKXiEBaRc5Z2Sdkf3BgeEfmaqBSJ2QhmY/MV7wprG9HghHyNaZtSSXAaTNkqQS6EaY06RzZ0dnTtMrO7EjvVuoQ2peB0V5aQQeozw2vyIfk59QHpPesUnnxBkF1+Ka1gYlxx3pD07buY8EIMKILkljeP7Y6owWdUUWRJ4TUgix8Qe3IyEM23S4VmtI+INHLdIGa+DE+Qg5TKoV6Go9nLonHrfLLkkZghNdngeng6596LZ0T1+6v+GJ8wJrBtNawjfnR9ZQjTB6ib472kNpj68CI+uKLqX9RPlDKnzohuxsbztXSacGMF5npW1RyIY1/8ih+dTlmADMKut1FI4d/BP6U5l0+1jaI/igmgIoqnZ86/HfIp/4+Z4eUHUEm1BlH/uIPJVl5prWmWtaOZQG7DDzRgTRb8juSEfWbN6odkapyTuTKIi8cEyhw+0p+kDynmc1LROIdFv8v2v5YUNXU/cbcXlaW3v2Hdkd63xLCyE2hRUbX1cDlOZHOSIIDB/z7BM1ONlRO20K0wOk/eFgzMw1rSPXtFIoNf2LNpLWu8hh2m8oL0+0h3JUQ4dba0lCTwojO1rGs57NC9H5sKnrUSCpc/ou7QzZERF6AaMbrBE4fUMO79jp2baRc6UKJgJAIVUDFEeS5x3AGYITa/8UpDVYPkBKQxSph6ZpVpp6WAmUnHCNPw6H+Amj18hA2u+eZyLbS2ID40CyeSIbY/Ng0vBLQy/G3hZIhJDmljwIMUHIEbuA0S2QAyc9uXGY/h5KSCkACKen0mqA0mS5N5qnAzrAYnDy5o8+QR9Q2ygvivoDwHkHppUM0iwdShKuMZnN3NEu8kUbf+/ab91jjG2ZyF4kVLMw8obtbWLaNgUTnRPdkAKIENLEeAEiACu3uaH1S+DUIP3eDTKgeNyzMWyii7JhXg1QbBoCalGwd7IGpsNJAVWbU6quie6tKGdhCcWyj/OlQsnkjxiu7SC5I8LoD2QgsQiN7ugB8szsqaGahZFXzGiH7O3oWM0ZaYKaSWoFkEIoQPQLSX5nD1DsBwoprSeaAiiO7nFLSE2pzRuCE5D2R82D5pxsWKeujeHkHUjh77LDuaVByckfPUb6MveRL9j4J/KVZF8gj6zxS54nVBuCEcMzgsgO0x/JfY40KIgYmnkgKiAEBIh+dTmAAtKxAuTOr2HeEKA098TpVZzBQEhZONXyrl7/4WN8ncKTcOLo+CNpdGo6Y4Lh3FLzTEuBUgckzR89QfoSX6C8giyBtI/85fKDkt5j7mgKjLSI8ZM0hZE6I+aKND9kQQRul/Xlh26fFFDALHqwYd4UQHGETIfvdVRaR8voZObJwzayZdN94v5ojZXmthSCS80zXRlKAiTmj3aQvsBXSIlsOiSGbBxdYzKbH06/JE/zwIgQOkSe86OFjHRG6op6o2UICIWuqJEwbwhQzO8wlNuVRtekxZtMgXgj1sAwmIASZN7+aOEnG+F0AskzXRVMV4KSARLzR/soYfRHd5/1R0+Rv7gpw/wWRkxgD1WrHqIEEsM0TVxrxWrPFQWIQsvWREAxT3SKfFw/RjqO6Zw4HYuj2XsoCyHnre3zXJPCiYCykLKm4huAs6uCaWEoSVKbIdsOEnheI4Vq/0aCkia0n3SvVYsJ+F+U2mCd+sEEtv5oNRh9Qpkz+o5+0pqwCxCF1qYBQNnjnLlRpiM+IuecGNK9kLaHabMgbJ+zron928JpCEpAZyCapmkX7U8LQakCJDqk/3TtX919JrQ1fzQW76o78pwRR9DGYMTaCjvNYxaeLfrFhULLkgGUdxLmsX+KdFwzb8tjX/Oln5HnizJva/NNd5FVg5PmeBVOWoelTgwo+227aPJ7big5w/5PkL4AOqT/ILmkP5CBpMQmrYH+F+K5I+uM7Az8A4wvZMV8Ubii0EZLjssLcVA6945w8spbLJjomlhOwLSJDiwBPphalMahQZlr0vIAIO+npkOYY5qrr80NJeSd47D/c6Sk9h9IMOIo2ytkIE3JH9XcEXNGR8gQ+oA8y3kIRoUzmvfLCYWuU93xWqsi59QmLQhWUH1CSqfsI4/aEU5aglNzTQomzzFp+kUHnnT0ukU2A5M1F5ScxPYzJCK/Rsof/Yl+yKZAAobdET+cuqNjJPB8QF4w7T0SkD4hD+8HjEK3UgInOie6EvYV66AIJYLpJVKf3Ed9KpfnmvQ2oyPCic9pn+W+EEyXWCC/NBlKA3kk1iHZokjrkIA6kPRL/oHsjjis/x7pSiDvUAKJ00ECRqFbLx7PTVpGZAhOJ/BDOg74MKzzpnVRHpwUXkA/qqGDs2C6nCe/NAlKDpCeIk8d4dC/OqSpQKI74gf7jnI52fdIIFIgHSJ90fyCf6CsMQoYhW61DJxsH/LyTmw8iTOq2EV9ileLejhHbjxCf7TQTs+aO780CqUOSA1yYvsx0ofRSu3fkSzic+RRthqQauGauqMDZBi97W4zf3SMvJRCEb9O+cCh0G2Rk3NS10RA2NUw2NiHfiCX67RIYALGwcS8sk25fINfC8j9G+2jo1BCTmwzj/QcCUC/o5zLtof0wXSUjX9Pabh2iUx2DnXSHRFGCqQjlMsnEEaTbWEodBvlwMlLihNQCiXCQ8HBETpgHEw6Am/dEpuCaVJ+aRBKJmx7iH7YpkBipTYtoB1ls/mjc2SbeYTsjt4iXR+NIdsh8iVhaAsjbxQKGY3AicD4apqFEvvTGJj43D1kNjAFQ3em80q9/+FqzCmpS+LwP10S57Jxcu08QGIxGKux6Y7eIDukD0hA+gxZXAoRqoVCg2rb2XXsvLBOywk09zPLycpbTQETCyo5+KU5LTqyov+OuaUqlEyRJJPbHG17jbx8Lefa2MS2lQKJVdmHyKHaP8gO6QPK1e7CHYVCc6jimhRObDUgUUNg4uPML10gDXRxBFAT7HRMQ/8LwLBTokvSIskXKK82MqUWqUUmNkO2z0jh2lsAf3ftHyQgMX/EcG1m+wJGodB86lwTkJPMF9I4am3DKtvPamDyEt9kBfPErDjnaPkZRtySC6WBXNJLZCDpSNtQYtsD0iESkP7q2t/IQOLomiazwx2FQgvKuCbtk5dy38o6IgWT9zrNL3Hq2QvkIk7NC59jwC3VnJIdcdtBORt5F3nFSJ3PVssjsSjyFGkH/4cEor8A/BcpbCOQdHQt3FEotCSZXJNtNTVOA8q+ThOjzHiKDCZdQmjULfWg5LgkUm8f5dVqvTltVppH4ijbe5Rh25vusWKHEUAKhZYucU1A6ms1EUB3pOljXn/XMgEuh72HxA4tev6GAbfkOSW6JM2oP0d6Yy4k5YVtKtKXQ/9MbB8guaR/UOaQGLIRSBGuhUIrVNu2lwNgUhjd65pOwt1CmVvi30D+hmkfsmMfZfHzD1TcUgElqd62odsu8kp3Y2EbkGPWn0gx5BekHXqH5Iw4yqYh2xmAi/YKK9aFQqHpqoBJQzFdafI++ou62X7Px+iWOGlf+cG6w6+ouCXPKSnpaMH4hjZsqwGpRR56tGHbWwSQQqGNkAMmQukeUj9/iPKKJjp517ol+/dM/yhDdpDyyifIbqlRt2ShpG/I8vEdlJd2YdhmZwxT6pJ0tI3V2qxDOoLYOAwn20Kh0IpkwGRzyo+Rl9/lctZDpsRGW6xxfIZymV7C7dz8fRVKdoeewt8hK80lcbTtCAlCnGDLwkgd9o+kdih0jTJg+oYUxajTocvhcidT3RLDuCfILNlGOWn/Qv94lqQ2+SRC6RHSTnApTU1ue5QE/FwSofShu88MfAApFNoc0VDorIuPSKmWQ+RZFrO+i3qEo3kpGpwnKJflVZYUf6hSp/QA+cJ4BJK9ComKLukS5dw2fihdmI1DghcBpFBoM9T1RVtXyLXN2H85F3U2Uo4+mAiZodyUNTgzKVysU3qA8gqZYzVJQP5ATHBzwi0p632gUCi0IerAxCko35DXOOPFOnQKGN2SpxpPtlHypEEK1GZMsY6HZFOnZF0S/9iCyZYBkLKfkK9OG9XaodDmS0fPGcYRTHZe6thUFQ3jHkizV0OZyTolvgHtlrqkofoE7pC1fpyQ9xl5pbshuoZCoWuWCeN0iWqu960pmKG8krolFmFuyW03N30HKJLc1ik9RC6ccuM/ET+ILvR0gvQBmNiOKSSh0M2QJr0Jpi/I63zrCh41l8Qtzc492d5BhSdeolsrOdnUao1BiU6JCz1xdbszhEsKhW6SOHeVC8NxtUoaDB2BGzMZanwap83kJbrVLbFpgtuDko68cflNXd2Oq85dIlxSKLTx6voo+zQd04+ucXG42uibSpnhwUifA1AvCaDd0qYuaQqYCCe7kFQoFLo5Yp8mnNiX7f7zvWQAABV/SURBVMJwY6pFWD15TknbkDvy1Mr2UtoYTUOh0GZKzYbXpxfp14NMIZTsC2r2agxO+lpNZE3521AoFJpBydKuRZ+EY1RUd3XPtLGiy1AotJnSfq3tKmZjkCUavlkQ0bKNwQjoA0nXYemVFGj1ZigU2mgpkHRYf16jMcaQmWyiW2NHJrSmXO2AalAWX3oV4fZ/hkKhDZOpXWSfVpOhMzyGwORFW7VIDIDvlIZGz4ZcE4HECXiczPsIZVX42IcIhUKbIQKJhdS1xd6m9Gkv+rJgAtB3LVpn9EPalEvuavjGeXNcqoBrsMzoGiFcKLTRslGProfU68/O36sDsuUEXvQ10x0AWijVoiwt/4ay+HFoqQI2OiUu7MQV68YuNhAKhTZAckWje+gv9PYMeaG2LQznlSyQzuFflbfqlDR0s2XlnCaiBZCeY1K6chlMLqfL9b1nYAq3FAptpKy54MVD9lBePEShVHNLZAqNjpocd9pZDUpcpM3OdRmbFaxJMb0gHT/MDvoXHgiFQhuizigwN0xjwT68D/+KRlY2P+3xZLaEEVBeUu2eeTNaLb7JKcpJtVNmBd9Bec04XlnXLvL2E0iXEo65cKHQ9cuEbQ9QXlCSF6L1jEXNJTFs01VDTpDXVZt0iSWbU+IbnaI/M5iEtDukH4pX132JBCSuw6KUvGyaJibphkLXL02/MGwjkHgxWuaTpqwaogbnRJpdW82HUtu2bdM0fCPO8j9FXg/JrqHihV+kJocRHyPZvZfIO8TkucaUPwNModD1qWkaTb1sIzmkfaS++xIJTM+R+vRQeY8OmKlL+oJsTDRa6uWUPKfEOFCh9BnZdmnC29sptYAM4exaLHZ9JR39C4VCa5QBEq9quw/gFYDfuu0ekkuyCW5Pnkv6jMwRXfCxl76xUALK5BQJZ5e0VfvWotw5WxpAt8QRPa/M4BIpv4Q2rpIbCq1NFSC9APAawB8AfkeCEl0Sr9c2xSXpFVHYvPW9CxVQMiGchRLX532O8USXrXN4ilyQSSB5RZlnAaZQaD0aANLvAP7s2u/dYzuYlkvSsiKu03+ENNClUHJDN8B3SgzhaL30EiufkJJdthDSc0tA+sBbSB9YK8XPUK5epzt31pUvxahcKLQiVYD0Eskd/QvAf5Cg9BtSn3+C8VwSR+/PkdlxhMyO3iXWvD7uQQko80onSG98iBRXcgdZ0akJb28kjh/8MfIOs3nZ9wbdTkfyOxRarmSibQ1I/wbwf0hg+h0ptzSWS2LYZrnxCflCtB8x8bqPPSg5IRyhdIAEJFurQHLeNW/VIP1TW/fAeS927gtDvjuQ68MFmEKh5UjqkLyQTYH07+6+hm1TqrcvkMM2GpkPKK+OPXrdx5pTstlzXn77A3JlNq8Jrm7JUpS3taBSqWqBdFfaHWQwVa1eKBQal1MYyTok5pAUSMwjPUOZPx6q3tY89DESkN537QAJUjQbVZcEVKBk3NIPlFbsGcq5bF6cORVMfJ5fll5B5R7KTH2Ec6HQnDLhmq3U5igbc0j/QnZINSBp31YgsbaROej3AN5120PkwulBlwTUnRLgu6VDJBgRSrqEAV3SXfQT30D+UPflMXVI3mqVWyirwC+apunNlQmFQn2ZcI2GgCU6BNKfSDDSkbapQALK0Tamej4gAeldd/sIKaQbzCVRVSh1bonZdI0TD5BsH6GkIRzBZEfkNL8EZDApxRVKvDIvV6z83L2G8Wi4plCoIuOONH+k075Yh0QYvUZKatu5bWNAonFhPdIBEoz+h+SSPiIZi1lt0li/HXJKBJMO8dEtPUZeI8lbhQ6YBiZ+eQzdCKRt2RJOx8jFmxydi1xTKNRJYKTuSPNHu0iFkK+RQPRHd/sV8gAW+/M8QPqKxAYC6W23PUDqt0UFN0Y0CKVOGsbRLXGpW8JDP0SD7ITGwGSJbsH0yGyPUIZzs1wTAk6hX1gmVONsCq7+uoM8j41A+h2pBknntNmoB5gGJHVIb5Cg9B4pt3QKSW5P6aOjUJIwThNZBAfDLBu+AdPAZMlOx3QfJZh0WV1WhtqVCwgnTPngodBtkJPI3kJeT3sHCTg6j+01yvlsHElnP76DxYD0PwD/IEHpHRYI26hRKHVSt/QVybEQHhwp44fRDzIEJoojb43cpmNiYo5rA+8gJc4OkfaBxVjFqgMBp9BtlwnV7qEc6ufytXtI7uiVaVyszY6ga/+dB0hvAfzdtbfIye3RQklPk6DUuSWgnNPCL0LrivSDUDUwQW6zzsmLh2lBCSW2D0g05nyaIqRDglOLiZYxFLoJquSNGKrxBL6L7I7YXiKviUR3pIv/a+SiGgLSByRn9DeA/yI5pXcow7afmLMPToIS0AvjviF/MQ3KD7MImDSco+OyibrHyOt9P0MeAaRr+oL8Rei8usg5hW68RmD0CLlUZxcpT6QOaR85VOMUMbqjWv4IGAfSWyQY/dVt3yL1x89IjJgrbKMmQwmoggnoE7aVLdtQRt+Gc4xtPcfExB0B9Ry5YlTXa9HlUZgQb9FN/p33iwqF1q0OREA+YTM6sTDiyBpXiSSUXnSP2WJnTbnUzMQiQNLRtoWABMwJJQBo2/ay+67Oxl6K9IHYHsG/xJIHJ3VfTODpqBzDOUJpF+VMZF0tU1e6jNAutPESV+Q5IyaxLYx02Vo6I0YUj1BeENaLcFQ0ErUc0huUQHqDBKpjSB6pXXAJormhBIyCST8QPxTbJTKY6JpqeSbIawgm7yzxHOkH+Ihy3RY6JwLKg1O4p9BGyHFFWiajI2qMFBRGCqJdlDMuGKrpyNoQjLjVSm0vqb0SIAELQgkYBBOhRBBxHSWOjvHyLEP1ELzfIENLXRMrv5nY47DnMTKQPkk7Rs45eStf0j3NJgkHoEKrloCIjognYE1bMDrQnGoNRjrTgs5I+1mtrwH9cM2uHMlhfya1GbItFUjAFaAEjIKJH+wM/YXdeEWEB8g/AuXBCShH6DSk20YG0wnymuK6uNQn9J0TSwm4bz+R13eahXdAACq0PBkQKYw0EiCM6IwYqjEqIJB2UcKIRcYWRkOhGtAP11iTqMsWvUMaXeMom+aQlgYk4IpQAlwwqfU7R14Cl41g2kH6ArT4Un8wlbW2tST4M6QviMtwvkDpmo6Q3ZTNO+moHdd8CkCFriQDIW7VFd1DOe+Trkjzppo7ZeMSQhZGhNtUGHHLiOEHyhVn6ZDeoCyOPMQKgAQsAUpAD0wavimUviGHTnQoz5DDOR2dmxrSeXBiSMe4+wsyiBjaKZw4YvcVZWg3BCggIBWqyHFDtfBMXZHOXtDSl+ddeybtafe6RWEE5H5q+yrnsX1EmipCIL1BnmTLAaXZnLZlAQlYEpSAAkz6Qa1bIpgsAEh7uqYWw/GvwonJcvtD67wfG9opoD6jP2JXA5Qm7C8BtOGiQhPcEBvDM46iEUTqjFjuoiCiI9JJ8DqaNi+MgHIg6gw5XDtGXqDtLfJctnfI4RoHjs6xZCABS4QSMAOTjU8JJn7wb8gdXzv/M5QJuilftD5mR+osnDS0O0GGkbYv0k7RBxTzYrqkb7ioX0wCIWDYDWloZl0R53I+lbbjNIJIh/U5Ijc1Z0R5fZPu6AvK/BEdki5B8hm5QJl1SEsFErBkKAGwBZZefolOiXDQvI6djzN15MA7SHhw2Fh9B/4+KJBqgLLuyYZ4nosCAlI3WhUnpBCyYZkNzQgihZE6IwUTC4QJIg4IWVe0CIy0P9IkcHTtE/LibG+RYER39AmpHzB/NLp65FW0dCgBMzAB3bwXlFl9hnIWCoTTHvLcnKnl8JQeNLXQTkc1NKwkeCykbGhHONn8GAHlhnkwoR63q/phQ4tpAEBjbkgdkQ3NHpvbBNITlBDS0OwBcjpDj3/CCLKtyYORuiOOrjFco0N6h+yOGK7ppPd2lcftSqAEzDobO6LGr+qYCAF1JSdIYOLowrzVqJQ+VwvtNLRUQHnAtGD6am7bEI8/IMsMFFKDoAICVuvQHADisXMH2a0QRA+k0Q1pnshCRwH1CNkNEUSMEGquCLKtycKI/e4Mud/p6BqBRBhZd8SJtRdYMZCAFUKJMuGcxrK0jyS2jpK9QjlvhyMNrAa3cALqP5Q+zgNN3RPhxOYBigBSEHkuT+Gk5Q9aPMrPb0GlB1LAakky+R9gfgBZN6SO24KIzQOSBZC6IQ3NFETqimBuexqCEUM19jMFEtsHZHd0inwMrzRcs1o5lABoOHeB9IXZkblvyMlnHb5nrdEuykpVD07UFDgB+cBrkd6HP+JD9AGltVYWVB6Y7Oid5qBqoLJOagqsYG6nB9Z08GyCHOgAffDobQuhKQDSRLUdwrfNc0OeE9JkNZsXBYyBCPBhZPNGCqOPyBeJ/NBtD1FZ2RVrcEeqtUAJwJRwjp3cDtsrmFijYUcibDIcGP4xPYjxANUf9iHyPrLVQj11UXycr9Hckwcqz0lNhRXs1gGX1caCbAQy3uO289bcj+eGpgLIJqyZl7Rg2pambsiOmCmEPBDB3Pakv7mF0TlyFKIwOuzagdzmnFEO6NAd8bhbK5CANUKJGnBNXjhHOH1CDudYv8GQzqvXWCS00/sWUA+QAaGQUkARQN/k9nfntgcqmygfCvt4W+EElKDywGU1L8jWoRpkaq+zwLGPEzx3TSOMpgLIu79ttppbqrkhD0LzgAiow4jHip7gPyPD6EAaXRFnNvBEqvV4a4cRtXYoAVXXZMM5z3LuI8/5YSLcq+HQA7EGHqshQLVI72ldnueiNOSz4Z8FmAcm/ZshWDEvRfjofllwWbVOmwKyVcmDTK3jAnXoqBOyLkiTxwTSVAApsAgdvW2T00NuCM52TPp72N9aT47sN3oy1zDtEP0J6jz+9Ji5NiABQHON/3umzrLrQXYfuaaD8384GXEfeVKizv9hQtHWdSicvANjilpn6wFK3Qwha4FlocODwj43BCs9o2lIZ/8nwWV/ZG//x0C2SnmQ8TozkOFloWNhoOCxzsXLDw0BSMFjAWf/r3Vti7ghoA8iewK30QVhRHek4RqbhmnWGV07jKiNgBIwA5OFEw8QjmbUJibaeUF0T3ZkQ8+kixwogH+w6EHTIv/I3Gr4dW6azSt5Tsk+9gN9t2TPmoUVR5IH1akgW5WGIGM7N19fgw6PG76X52a2zHM27KoBiO/N45PbZUEIqB9behwxmqDbts6IzVsh4wQ5iU2wbQyMqI2BEuXAiQcfk4paCUsgKaj4GN2TOic9ww2diefREKTsGa4Gqhq0arA6Q3lQ6QGrr9OzINCH0hSQrVpjkLEdXY8Lm8O5Z5rnlGwIt2VaDUBDoaU9ZuY5hmrHjzpwuiLCyOZdj1BCiCEaCx8VRjzxXGveaEgbByVqAE6027ZUX8GkoR0T4sw78UDWs7Ee/HC2U2W/TAuBGqgstMZgRXBouOUBpsgTIEsP+jGQrVpDkCEQ9PewYb6Fkj7vwUbbIgAC+sfFVY6TIRBpiMahfZbO0B3p0jyaLzpBLk2h254dM5sII2pjoURV4MQDWAHF3JMX1nlzinS4tpbHsGfBeQ8+YBqo9P4UWF2Y51p53gOX/h/I/XlAtgqNQcY7WTTIUPGgo1C5W3lcf+dVA4iaF0QaotEZaamMLsHD8Iww0tkFveNgk4EE3AAoUQ6c9KAknNQ5EUjezGudfU048b30TOqFeFeFFFAHFW+Pwap1msLLgsu+P7fzgGwVGoIMH7Pfu4LEg06D8jebAp1lAwiof+fzgMhOw7IwIoi0Pu47yt9ydrxsOoyoGwMlSuCkgLJwYu6JTWFk16nxnJPXOcZcFJz782oKrOxtva9wstBS8f5UkK1SY5Dha/T19hiwvwsGblNj9+eV9x0PnTTGQKQw0uV1NDxj0a6G3poTvASwMYWxU3XjoERJ5S8PSIUTc08PkfNJhBOBZMsJanOTFFLqotghVgkpaghW9vEauOzr9DVTQLYqjUEG8L/HMejw8aH7i6r2e1gItciOSB0p80RjILIT1RVEzDN5OcYb44o83VgoqSqhnY6wPICfHNe1bGqzuIdmcI9BCuh3hGV1DKup4LKaCrJVawpkrK7zu/Wal/+zo6I6lD8GIp38bedS6ijajQvRhnQroEQ5od0d9IeH6Z4eD7TaDO/adAILqSl5DNWqOtOYFgXZqnTd38vQ91FzQZeyVQido6wr41C+zRXVQGQndTNpTRDd6BBtSLcKSpSEdgonTaYqWHQOE93UEJh04qWFlI4EzTvMDHPbux9ajqbCR+/XXJBXW2bnOX6FDyRup4KoCLNvE4hUtxJKqkruieGdhnjqpJgs98I5r9l5U1Mrgmv5Ey98Gbsf6usq8LGNIFL4aDGrOiILIgWSt6LEZBABt8sVebr1UFJVwjvNCzHMU0CpiyKs6KiGADU0deGeNAuoMUflAYv6lcA1NfRcBD7qhBRGCp/aahBsuq7WV/OcOikWNv7SIFL9UlCiTHhXg5TnotgUVI9kq6HdlEmenpOqgaqBDyxqKrhUmwSxqZBRebCxz9UANAQfdUPc2mkeChwPTrrV3JKFUIDI6JeEksoAituai9KQzIOUbu1te98my7fgg8ruw1givRYSWi0CsVVrCDL6Gn3edmYPRlPhY92QhmZ2GF+3Cp4zs9X/o0nqAFFFvzyUrEZclOekFFL3zVYd0hiY7pv7NtTT/2XLEHTfrlp8aF+/ak2FjH29BY52cv69Vx80BB+bG7LP2QQ2X6fvqw5IIWT3LUBUUUBpQAIoYBqkPIBoTsmCygPSQ3nMvo8CS8GjI4seuGC280Bs1ZoCGQUXtxY45+gDgM/bpPQYfCysFGRnzuMEEP+nDRV7cA0Q1RVQmkMTIcXOfgdlrsgCxoZrNadUe44jefw/Woul4PLCtHkgtkpNhYx2aN62wDlDCYdLlAnqeeHjhV0/TauFYQGhKyigdAUNQKrmqCyoatDyQrchp8TXWHDxNdYl8X+OQWwdGoMMO71CqeaCCJAxpzQVPl7oVXNB4DYAdDUFlJasSuJ8yFV5YeBd0yy01CXxb2vg0v8N8/oxiK1DY5AhFPjaIYjp661bWhQ+nvsJF7RCBZTWoAmg8oDlOS1v9M26JQsuC6UG0yAG2a5CU8IxQsa+liCzwFGX1MptzVPNCx/INgC0BgWUrklO6MftmMPS+0D5XA1c9n9NgRhQ/t2yZUEzBBk9SPX1FjgKGKCETcDnhiigtGEysALqwPKesyDSppoHYqvWFMh4r9dmgYPKNuBzAxRQukFygAX0XVANXKp5IbZKTYWM/Ru71df1/ibgc3MUULplmgAu+/gUiK1aY5DxXpsfiIP4Vimg9ItrToitQgGZUKGAUigU2ij9fxtpzF+umZflAAAAAElFTkSuQmCC"
+         id="image42" />
+      <path
+         class="cls-5"
+         d="M388,261.91c-6.22-1.87-7.29-6.85-9.56-12.24a42.88,42.88,0,0,0-9.82-14.6,38.06,38.06,0,0,0-32-9.89,34.45,34.45,0,0,0-10.75,3.95c-2.66,1.45-5.16,2.53-8.27,2s-5.89-2.75-8.83-4a32.46,32.46,0,0,0-11.21-2.46A37.92,37.92,0,0,0,268,237.37a48.34,48.34,0,0,0-9.07,16c-2.32,6.54-6.09,7.93-12.45,9.72-12.79,3.58-25.54,8.36-37,15.2-16.39,9.79-32,26-28,46.63,3.31,17.08,19.47,29.08,34,36.53,22.57,11.6,48,17,73.05,19.63a294.1,294.1,0,0,0,86.73-3.67c21.83-4.27,44.76-11.35,62.65-25,13.22-10.12,23.64-25.36,19.08-42.7-5.67-21.59-29.32-33.88-48.42-41.26A190.37,190.37,0,0,0,388,261.91c-9.34-2.44-13.33,12-4,14.47,12,3.12,23.79,7.09,34.66,13.09,7.66,4.23,15.6,9.53,20.45,17,7.57,11.64,3.08,22-6.48,30.81-13.9,12.75-33.58,19.14-51.53,23.49-25.13,6.08-51.26,7.81-77,6.51-23.73-1.2-47.68-5.16-69.92-13.76-13.69-5.3-30-13.59-36.58-27.15a14.46,14.46,0,0,1-1.15-3.13c-.14-.52-.71-3.61-.6-2.67a18.66,18.66,0,0,1,1.35-9.66c3-7.24,9.45-12.87,15.8-17.14,9.67-6.48,20.48-11,31.55-14.49,5.73-1.8,12.12-2.69,17.26-5.95a27,27,0,0,0,10.82-13.84c3.54-9.65,9.4-18,20.3-19.63a19.71,19.71,0,0,1,8.61.54c3.73,1.15,6.82,3.69,10.6,4.8A26.37,26.37,0,0,0,332,242.91c5.51-2.89,10.61-4.06,16.7-2.4a22.89,22.89,0,0,1,12,8c3.87,4.89,4.68,10.86,7.78,16.09A26.72,26.72,0,0,0,384,276.38C393.3,279.16,397.26,264.68,388,261.91Z"
+         transform="translate(-112 -195)"
+         id="path44" />
+      <path
+         class="cls-7"
+         d="M259,258.2"
+         transform="translate(-112 -195)"
+         id="path46" />
+    </g>
+  </g>
+  <metadata
+     id="metadata870">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>praat</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="matrix(3.2509231,0,0,3.2509231,222.58913,213.16386)">
+    <rect
+       id="rect2879"
+       x="7.7378001"
+       y="42.43"
+       width="32.507999"
+       height="3.5701001"
+       style="opacity:0.3;fill:url(#linearGradient3406)" />
+    <path
+       id="path2881"
+       d="m 7.7378,42.43 v 3.5699 c -1.1865,0.0067 -2.8684,-0.79982 -2.8684,-1.7852 0,-0.98533 1.324,-1.7847 2.8684,-1.7847 z"
+       style="opacity:0.3;fill:url(#radialGradient3403)" />
+    <path
+       id="path2883"
+       d="m 40.246,42.43 v 3.5699 c 1.1865,0.0067 2.8684,-0.79982 2.8684,-1.7852 0,-0.98533 -1.324,-1.7847 -2.8684,-1.7847 z"
+       style="opacity:0.3;fill:url(#radialGradient3400)" />
+    <path
+       id="path4160"
+       d="m 6.5,0.4972 h 24.061 c 1.4069,0.47465 8.9655,5.8822 10.939,9.6264 v 34.379 H 6.5 V 0.4966 Z"
+       style="fill:url(#linearGradient3395);stroke:url(#linearGradient3397);stroke-width:0.99992;stroke-linejoin:round" />
+    <path
+       id="path4191"
+       d="M 7.3617,44 C 7.1624,44 7,43.82454 7,43.60922 V 1.40522 C 7,1.18951 7.1624,1.01444 7.3617,1.01444 c 7.4831,0.10801 15.776,-0.16158 23.25,0.026895 l 10.283,8.866 0.10598,33.702 c 0,0.21532 -0.16204,0.39078 -0.3617,0.39078 h -33.277 z"
+       style="fill:url(#radialGradient3392)" />
+    <path
+       id="path2435"
+       d="M 40.5,10.259 V 43.522 H 7.5 V 1.477 h 22.866"
+       style="opacity:0.6;fill:none;stroke:url(#linearGradient3389);stroke-width:0.99992;stroke-linejoin:round" />
+    <path
+       id="path2704"
+       d="m 34,29.632 c 0,1.3082 -2.4694,2.3687 -5.5156,2.3687 -3.0462,0 -5.5156,-1.0605 -5.5156,-2.3687 0,-1.3082 2.4694,-2.3687 5.5156,-2.3687 3.0462,0 5.5156,1.0605 5.5156,2.3687 z"
+       style="opacity:0.3;fill:url(#radialGradient3386)" />
+    <path
+       id="path4121"
+       d="m 22.569,31.425 c -8.55e-4,1.4225 -2.6862,2.5754 -5.9986,2.5754 -3.3124,0 -5.9977,-1.153 -5.9986,-2.5754 -8.56e-4,-1.423 2.685,-2.5768 5.9986,-2.5768 3.3136,0 5.9994,1.1538 5.9986,2.5768 z"
+       style="opacity:0.3;fill:url(#radialGradient3383)" />
+    <path
+       id="path4031"
+       d="m 32.466,6.5042 c -4.1269,0.65819 -8.8722,1.3357 -12.988,2.0307 -1.0898,0.52625 -0.84479,1.8813 -0.89301,2.8646 v 13.162 c -2.8008,-0.6412 -5.8751,1.4509 -5.9966,4.4247 -0.19829,1.8514 1.4606,3.463 3.2644,3.5063 3.2297,0.07759 5.6844,-2.0431 5.7194,-4.7252 -0.03527,-4.5043 0.0099,-9.0104 0,-13.515 0.5,-0.03665 8.319,-1.4668 9,-1.5621 v 10.122 c -2.5834,-0.76106 -5.1657,0.82954 -5.8019,3.4956 -0.47074,1.5444 0.23898,3.3701 1.7711,4.0028 2.9909,1.3602 7.1978,-1.395 7.0308,-4.6285 -0.04632,-6.0063 0.03797,-12.015 0,-18.022 -0.07855,-0.56448 -0.46504,-1.1967 -1.1066,-1.1559 z"
+       style="fill:#4d4d4d;stroke:#333333;stroke-linecap:round;stroke-linejoin:round" />
+    <path
+       id="path2937"
+       d="m 20.708,27.768 c 0,1.9878 -1.7443,3.8972 -3.8959,4.2647 -2.1516,0.3675 -3.8959,-0.94604 -3.8959,-2.9339 0,-1.98786 1.7443,-3.8972 3.8959,-4.2647 2.1516,-0.3675 3.8959,0.94604 3.8959,2.9339 z"
+       style="fill:url(#radialGradient3379)" />
+    <path
+       id="path2941"
+       d="m 32.75,25.937 c 4.91e-4,1.9881 -1.7439,3.898 -3.8959,4.2655 -2.152,0.3675 -3.8964,-0.94646 -3.8959,-2.9347 4.91e-4,-1.9876 1.7446,-3.8964 3.8959,-4.2639 2.1513,-0.3675 3.8954,0.94563 3.8959,2.933 z"
+       style="fill:url(#radialGradient3376)" />
+    <path
+       id="path2945"
+       d="M 19.179,25.166 19.085,10.121 c 0,0 0.1029,-1.1502 0.86617,-1.1537 0.2707,-0.04687 12.136,-2.0041 12.136,-2.0041 0,0 1.5321,0.72791 -11.015,2.7677 -1.2871,0.24744 -1,0.73094 -1,1.58 0,2.2902 2e-6,6.0215 2e-6,14.36 0,0.05966 -0.56979,-0.4227 -0.89325,-0.50513 h 2e-6 z"
+       style="opacity:0.3;fill:url(#linearGradient3373);fill-rule:evenodd" />
+    <path
+       id="path2947"
+       d="m 31.072,23.434 0.0594,-11.366 c 0.62592,-0.05597 0.0961,-0.009 0.94012,-0.09284 0.01161,2.123 4.8e-4,3.8852 4.8e-4,11.903 0,0.05966 -0.34916,-0.36221 -1,-0.44464 z"
+       style="opacity:0.3;fill:url(#linearGradient3370);fill-rule:evenodd" />
+    <path
+       id="path12038"
+       d="m 28.617,0.92126 c 4.2825,0 2.1532,8.4832 2.1532,8.4832 0,0 10.358,-1.8023 10.358,2.8187 0,-2.6097 -11.302,-10.729 -12.511,-11.302 z"
+       style="opacity:0.4;fill-rule:evenodd;filter:url(#filter3212)" />
+    <path
+       id="path4474"
+       d="m 28.617,0.92126 c 3.1865,0 2.3358,7.6619 2.3358,7.6619 0,0 10.175,-0.98105 10.175,3.64 0,-1.1259 0.08591,-1.9322 -0.13378,-2.2836 -1.5783,-2.5242 -8.3955,-8.1884 -10.857,-8.9308 -0.18422,-0.055555 -0.5927,-0.087535 -1.5198,-0.087535 z"
+       style="fill:url(#linearGradient3366);fill-rule:evenodd" />
+    <path
+       id="text2457"
+       d="m 15.96,40.912 h 0.82 c 0.35667,-1.1967 0.71333,-2.3933 1.07,-3.59 0.35,1.1967 0.7,2.3933 1.05,3.59 h 0.83 c 0.66667,-1.8467 1.3333,-3.6933 2,-5.54 h -1.42 c -0.33667,1.1267 -0.67333,2.2533 -1.01,3.38 -0.30333,-1.1267 -0.60667,-2.2533 -0.91,-3.38 h -1.06 c -0.31,1.1267 -0.62,2.2533 -0.93,3.38 -0.33,-1.1267 -0.66,-2.2533 -0.99,-3.38 h -1.43 c 0.66,1.8467 1.32,3.6933 1.98,5.54 z m 12.078,-5.54 h -1.22 c -0.04548,0.21594 0.12916,1.0307 -0.17703,0.52748 -1.0936,-1.1556 -3.2097,-0.71377 -3.9931,0.59594 -0.92047,1.4249 -0.44604,3.6848 1.2108,4.3314 0.99099,0.41639 2.277,0.25809 2.9594,-0.63484 0.05937,0.21054 -0.1196,0.65942 0.08973,0.72 h 1.1303 v -5.54 z m -2.89,1.09 c 1.1193,-0.06598 1.8834,1.172 1.5667,2.1827 -0.22339,1.2805 -2.0732,1.5712 -2.833,0.61315 -0.78554,-0.94966 -0.21869,-2.7174 1.0915,-2.7875 l 0.17475,-0.0083 -1e-6,-10e-7 z m 5.5816,4.45 h 1.06 c 0.74333,-1.8467 1.4867,-3.6933 2.23,-5.54 h -1.5 l -1.26,3.67 c -0.42667,-1.2233 -0.85333,-2.4467 -1.28,-3.67 h -1.48 c 0.74334,1.8467 1.4867,3.6933 2.23,5.54 z"
+       style="opacity:0.4" />
+  </g>
+</svg>


### PR DESCRIPTION
This commit adds two new files, a desktop one (`main/praat-file.desktop`) and its associated icon (`main/praat-file.svg`). These files are currently being [distributed](https://tracker.debian.org/news/1327368/accepted-praat-6213-1-source-into-unstable/) in the Debian package praat.

With the new desktop file, it is possible, for the user to drop audio files on the new desktop icon, which will open them thanks to the `Exec=praat --open %F` directive. Since the `MimeType` directive is also defined, utilities like the Gnome file manager Nautilus automatically recognize the praat-file application as being able to open audio files. This is a screenshot of the situation where the right mouse button was clicked on a WAV file and "Open with Other Application" has been selected from the dropdown menu: 

![Screenshot from 2022-05-25 08-52-21](https://user-images.githubusercontent.com/4037976/170202193-2c522d1b-10a1-4488-a39e-7ef8795f8fc1.png)

