### PR TITLE
Do not replace ` ` and `.` by underscores.

### DIFF
--- a/sys/praat.cpp
+++ b/sys/praat.cpp
@@ -333,7 +333,7 @@ void praat_cleanUpName (char32 *name) {
 	Replaces spaces and special characters by underscores.
 */
 	for (; *name; name ++)
-		if (str32chr (U" ,.:;\\/()[]{}~`\'<>*&^%#@!?$\"|", *name))
+		if (str32chr (U",:;\\/()[]{}~`\'<>*&^%#@!?$\"|", *name))
 			*name = U'_';
 }
 


### PR DESCRIPTION
See: https://github.com/praat/praat/issues/2321#issue-1581039473