### PR TITLE
Use numerical value instead of string as third argument of Derivative

### DIFF
--- a/dwtest/test_Electroglottogram.praat
+++ b/dwtest/test_Electroglottogram.praat
@@ -11,7 +11,7 @@ sound = Read from file: "s_egg_test.wav"
 egg = Extract Electroglottogram: 1, "no"
 textgrid = To TextGrid (closed glottis): pitchFloor, pitchCeiling, closingThreshold, silenceThreshold
 selectObject: egg
-degg = Derivative: 5000, 50, "yes"
+degg = Derivative: 5000, 50, 0.99
 selectObject: egg
 To AmplitudeTier (levels): pitchFloor, pitchCeiling, closingThreshold, "yes", "yes"
 peaks = selected ("AmplitudeTier", 1)


### PR DESCRIPTION
Unit test dwtest/test_Electroglottogram.praat fails with this error message:

```
$ praat dwtest/test_Electroglottogram.praat
test_Electroglottogram.praat
Error: Argument “New absolute peak” should be a number, not a string.
Script line 14 not performed or completed:
« degg = Derivative: 5000, 50, "yes" »
Script “dwtest/test_Electroglottogram.praat” not completed.
Praat: script command <<./dwtest/test_Electroglottogram.praat>> not completed.
```

This commit fixes the problem.
