### PR TITLE
Fix typos in dwtools subdirectory

### DIFF
--- a/dwtools/CCA.h
+++ b/dwtools/CCA.h
@@ -45,7 +45,7 @@
 	c1 [p] = v1 [p]' . Table1   c2 [p]= v2 [p]' . Table2
 
 	the sample correlation of c1 [1] and c2 [1] is greatest, the sample
-	correlation of c1 [2] and c2 [2] is greatest amoung all linear compounds
+	correlation of c1 [2] and c2 [2] is greatest among all linear compounds
 	uncorrelated with c1 [1] and c2 [1], and so on, for all p possible pairs.
 */
 

--- a/dwtools/Configuration.h
+++ b/dwtools/Configuration.h
@@ -104,7 +104,7 @@ autoConfiguration TableOfReal_to_Configuration_pca (TableOfReal me, integer numb
 
 autoConfiguration Configuration_createLetterRExample (int choice);
 /*
-  	Create a two-dimensional configuartion from the letter R.
+  	Create a two-dimensional configuration from the letter R.
   	choice = 1 : undistorted;
   	choice = 2 : result of monotone fit on distorted (d^2 + 5 +32.5*z)
 */

--- a/dwtools/Covariance.cpp
+++ b/dwtools/Covariance.cpp
@@ -529,7 +529,7 @@ void Covariances_equality (CovarianceList me, int method, double *out_prob, doub
 		if (out_chisq)
 			*out_chisq = chisq;
 	} catch (MelderError) {
-		Melder_throw (U"Equality coud not be tested.");
+		Melder_throw (U"Equality could not be tested.");
 	}
 }
 
@@ -726,7 +726,7 @@ void Covariance_getSignificanceOfMeansDifference (Covariance me, integer index1,
 		} else {
 			t = (my centroid [index1] - my centroid [index2] - mu) / sqrt (var_pooled / n);
 			/*
-				Return two sided probabilty.
+				Return two sided probability.
 			*/
 			if (equalVariances)
 				prob = 2.0 * NUMstudentQ (fabs (t), ndof);

--- a/dwtools/DTW.cpp
+++ b/dwtools/DTW.cpp
@@ -32,7 +32,7 @@
  djmw 20071204 DTW_and_Sounds_draw.
  djmw 20080122 float -> double
  djmw 20081123 DTW_and_Sounds_checkDomains did not swap sounds correctly.
- djmw 20091009 Removed a bug in DTW_Path_recode that could cause two identical x and y times in succesion at the end.
+ djmw 20091009 Removed a bug in DTW_Path_recode that could cause two identical x and y times in succession at the end.
  djmw 20100504 extra check in DTW_Path_makeIndex
  djmw 20110304 Thing_new
 */

--- a/dwtools/Electroglottogram.h
+++ b/dwtools/Electroglottogram.h
@@ -30,7 +30,7 @@ Thing_define (Electroglottogram, Sound) {
 };
 
 /*
-	An Electroglottogram represets the degree of contact between the (vibrating) vocal folds during voice production.
+	An Electroglottogram represents the degree of contact between the (vibrating) vocal folds during voice production.
 	It is measured at the throat.
 	It will be represented as a one channel Sound.
 	There might be an accompanying sound. They are both sampled at the same sampling frequency.

--- a/dwtools/FilterBank.cpp
+++ b/dwtools/FilterBank.cpp
@@ -19,7 +19,7 @@
 /*
  djmw 20010718
  djmw 20020813 GPL header
- djmw 20030901 Added fiter function drawing and frequency scale drawing.
+ djmw 20030901 Added filter function drawing and frequency scale drawing.
  djmw 20050731 +FilterBank_and_PCA_drawComponent
  djmw 20071017 Melder_error<n>
  djmw 20071201 Melder_warning<n>

--- a/dwtools/GaussianMixture.cpp
+++ b/dwtools/GaussianMixture.cpp
@@ -88,7 +88,7 @@ static double GaussianMixture_getLikelihoodValue (GaussianMixture me, constMAT c
 				lnsum += pp * log (pp); // scaling outside the loop
 			}
 			if (psum > 0)
-				lnpcd += lnsum / psum; // scaling: as reponsibilities
+				lnpcd += lnsum / psum; // scaling: as responsibilities
 		}
 		return lnpcd;
 	}
@@ -142,7 +142,7 @@ static void GaussianMixture_getResponsibilities (GaussianMixture me, constMATVU 
 	Melder_require (responsibilities.nrow == probabilities.nrow && responsibilities.ncol == probabilities.ncol,
 			U"The responsibilities and the probabilities should have the same dimensions.");
 	Melder_require (responsibilities.ncol == my numberOfComponents,
-			U"The number of columns of the responsbilities should equal the number of components.");
+			U"The number of columns of the responsibilities should equal the number of components.");
 	const integer fromComponent = componentToUpdate == 0 ? 1 : componentToUpdate;
 	const integer toComponent = componentToUpdate == 0 ? my numberOfComponents : componentToUpdate;
 	

--- a/dwtools/GaussianMixture.h
+++ b/dwtools/GaussianMixture.h
@@ -82,7 +82,7 @@ void GaussianMixture_TableOfReal_getComponentProbabilities (GaussianMixture me, 
 autoTableOfReal GaussianMixture_TableOfReal_to_TableOfReal_probabilities (GaussianMixture me, TableOfReal thee);
 
 /*
-	Calculate the responsibities: mixingProbability(k) * N(x(n)|mu(k),Sigma(k)) / Normalization.
+	Calculate the responsibilities: mixingProbability(k) * N(x(n)|mu(k),Sigma(k)) / Normalization.
 	Bishop (2007): Pattern recognition and machine learning, Springer page 438: Eq. 9.23
 	Invariant:
 	The row sum always equals 1.

--- a/dwtools/HMM.cpp
+++ b/dwtools/HMM.cpp
@@ -810,7 +810,7 @@ void HMMBaumWelch_reInit (HMMBaumWelch me) {
 	my lnProb = 0.0;
 
 	/*
-		The _num and _denum matrices are asigned as += in the iteration loop and therefore need to be zeroed
+		The _num and _denum matrices are assigned as += in the iteration loop and therefore need to be zeroed
 		at the start of each new iteration.
 		The elements of alpha, beta, scale, gamma & xi are always calculated directly and need not be
 		initialised.

--- a/dwtools/ICA.cpp
+++ b/dwtools/ICA.cpp
@@ -185,7 +185,7 @@ static void Diagonalizer_CrossCorrelationTableList_ffdiag (Diagonalizer me, Cros
 }
 
 /*
-	The folowing two routines are modelled after qdiag.m from
+	The following two routines are modelled after qdiag.m from
 	R. Vollgraf and K. Obermayer, Quadratic Optimization for Simultaneous
 	Matrix Diagonalization, IEEE Transaction on Signal Processing, 2006,
 */

--- a/dwtools/KlattGrid.cpp
+++ b/dwtools/KlattGrid.cpp
@@ -2111,7 +2111,7 @@ autoKlattGrid KlattGrid_createExample () {
 }
 
 // y is the height in units of the height of one section,
-// y1 is the height from the top to the split between the uppper, non-diffed, and lower diffed part
+// y1 is the height from the top to the split between the upper, non-diffed, and lower diffed part
 static void _KlattGrid_queryParallelSplit (KlattGrid me, double dy, double *out_y, double *out_y1) {
 	const integer ny = my vocalTract -> nasal_formants -> formants.size +
 		my vocalTract -> oral_formants -> formants.size + my coupling -> tracheal_formants -> formants.size;
@@ -2250,7 +2250,7 @@ void KlattGrid_draw (KlattGrid me, Graphics g, kKlattGridFilterModel filterModel
 		ys1 = ys2 - height_phonation;
 		PhonationGrid_draw_inside (my phonation.get(), g, xs1, xs2, ys1, ys2, dy_phonation, & yout_phonation);
 
-		// units in cascade have same heigth as units in source part.
+		// units in cascade have same height as units in source part.
 
 		xc1 = xmin + accumulatedWidths [2]; // end of phonation
 		xc2 = xc1 + relativeWidths [3]; // same width as vocaltract

--- a/dwtools/Matrix_extensions.cpp
+++ b/dwtools/Matrix_extensions.cpp
@@ -391,7 +391,7 @@ double Matrix_getStandardDeviation (Matrix me, double xmin, double xmax, double 
 autoDaata IDXFormattedMatrixFileRecognizer (integer numberOfBytesRead, const char *header, MelderFile file) {
 	unsigned int numberOfDimensions, type, pos = 4;
 	/*
-		9: minumum size is 4 bytes (magic number) + 4 bytes for 1 dimension + 1 value of 1 byte
+		9: minimum size is 4 bytes (magic number) + 4 bytes for 1 dimension + 1 value of 1 byte
 	 */
 	if (numberOfBytesRead < 9 || header [0] != 0 ||  header [1] != 0 || (type = header [2]) < 8 ||
 		numberOfBytesRead < 4 + (numberOfDimensions = header [3]) * 4) // each dimension occupies 4 bytes

--- a/dwtools/MultiSampledSpectrogram.h
+++ b/dwtools/MultiSampledSpectrogram.h
@@ -32,7 +32,7 @@ Thing_define (FrequencyBin, AnalyticSound) {
 /*
 	A MultiSampledSpectrogram is a spectrogram that is evenly sampled in the frequency domain (on some possibly non-linear frequency scale).
 	Each "sample" is a FrequencyBin with real and imaginary values.
-	The original sound can be reconstructed from the data in the frequncy bins.
+	The original sound can be reconstructed from the data in the frequency bins.
 */
 
 autoFrequencyBin FrequencyBin_create (double xmin, double xmax, integer nx, double dx, double x1);

--- a/dwtools/PCA.h
+++ b/dwtools/PCA.h
@@ -60,7 +60,7 @@ autoTableOfReal PCA_TableOfReal_to_TableOfReal_zscores (PCA me, TableOfReal thee
 double PCA_TableOfReal_getFractionVariance (PCA me, TableOfReal thee, integer from, integer to);
 /*	Get fraction variance of the table projected in the pca-space.
 	Shorthand for projecting the Covariance of the TableOfReal on the PCA-space
-	and quering the projected Covariance for 'fraction variance'.
+	and querying the projected Covariance for 'fraction variance'.
 */
 
 autoTableOfReal PCA_Configuration_to_TableOfReal_reconstruct (PCA me, Configuration thee);

--- a/dwtools/Sound_and_Spectrogram_extensions.cpp
+++ b/dwtools/Sound_and_Spectrogram_extensions.cpp
@@ -295,7 +295,7 @@ autoSpectrogram Sound_Pitch_to_Spectrogram (Sound me, Pitch thee, double analysi
 
 		if (isundef (f0_median) || f0_median == 0.0) {
 			f0_median = 100.0;
-			Melder_warning (U"Pitch values undefined. Bandwith fixed to 100 Hz. ");
+			Melder_warning (U"Pitch values undefined. Bandwidth fixed to 100 Hz. ");
 		}
 
 		if (f1_hz <= 0.0)

--- a/dwtools/Sound_and_Spectrogram_extensions.h
+++ b/dwtools/Sound_and_Spectrogram_extensions.h
@@ -32,7 +32,7 @@ autoBarkSpectrogram Sound_to_BarkSpectrogram (Sound me, double analysisWidth, do
 	Filtering with filters on a Bark scale as defined by
 		Andrew Sekey & Brian Hanson (1984), "Improved 1-Bark bandwidth
 		"auditory filter", Jasa 75, 1902-1904.
-	Although not explicitely stated the filter function is defined in the
+	Although not explicitly stated the filter function is defined in the
 	power domain.
 	10 log F(z) = 15.8 + 7.5(z + 0.5) - 17.5 * sqrt(1 + (z + 0.5)^2)
 */

--- a/dwtools/Sound_extensions.cpp
+++ b/dwtools/Sound_extensions.cpp
@@ -506,13 +506,13 @@ autoSound Sound_readFromOggVorbisFile (MelderFile file) {
 			ogg_stream_state oggStream; // take physical pages, weld into a logical stream of packets
 			ogg_stream_init (& oggStream, ogg_page_serialno (& oggPage));
 			/* 
-				Eextract the initial header from the first page and verify that the
+				Extract the initial header from the first page and verify that the
 				Ogg bitstream is in fact Vorbis data
 
 				I handle the initial header first instead of just having the code
 				read all three Vorbis headers at once because reading the initial
 				header is an easy way to identify a Vorbis bitstream and it's
-				useful to see that functionality seperated out.
+				useful to see that functionality separated out.
 			*/
 			vorbis_info vorbisInfo; // struct that stores all the static vorbis bitstream settings
 			vorbis_info_init (& vorbisInfo);
@@ -865,7 +865,7 @@ static autoSound Sound_create2 (double minimumTime, double maximumTime, double s
 		sin(a+dx) = sin(a) - (alpha . sin(a) - beta . sin(a))
 	where alpha and beta are precomputed coefficients
 		alpha = 2 sin^2(dx/2) and beta = sin(dx)
-	In this way aplha and beta do not lose significance if the increment
+	In this way alpha and beta do not lose significance if the increment
 	dx is small.
 */
 
@@ -964,7 +964,7 @@ static void NUMgammatoneFilter4 (double *x, double *y, integer n, double centre_
 		Coefficients a & b according to:
 		Slaney (1993), An efficient implementation of the Patterson-Holdsworth
 		auditory filterbank, Apple Computer Technical Report 35, 41 pages.
-		For the a's we have left out an overal scale factor of dt^4.
+		For the a's we have left out an overall scale factor of dt^4.
 		This makes a [0] = 1.
 	*/
 
@@ -1685,7 +1685,7 @@ autoTextGrid Sound_to_TextGrid_speechActivity_lsfm (Sound me, double timeStep, d
 						const conststring32 vadLabel = vadTextInterval -> text.get();
 						const double vadEndTime = vadTextInterval -> xmax;
 						if (vadEndTime > silenceEndTime - timeMargin) {
-							// extends beyound the end 
+							// extends beyond the end 
 							IntervalTier_addBoundaryUnsorted (unionTier, unionIndex, silenceEndTime, vadLabel);
 							unionIndex ++;
 							unionContinues = false;

--- a/dwtools/Spectrum_extensions.h
+++ b/dwtools/Spectrum_extensions.h
@@ -42,7 +42,7 @@ autoMatrix Spectrum_unwrap (Spectrum me);
 
 	Tribolet, J.M. & Quatieri, T.F. (1979), Computation of the Complex
 		Spectrum, in: Programs for Digital Signal Processing,
-		Digital Signal Processing Commitee (eds), IEEE Press,
+		Digital Signal Processing Committee (eds), IEEE Press,
 		chapter 7.1.
 
 	First row of returned matrix contains the amplitudes-squared,

--- a/dwtools/SpeechSynthesizer_and_TextGrid.cpp
+++ b/dwtools/SpeechSynthesizer_and_TextGrid.cpp
@@ -600,7 +600,7 @@ static autoTextGrid SpeechSynthesizer_Sound_TextInterval_align2 (SpeechSynthesiz
         autoDTW dtw = Sounds_to_DTW (thee_trimmed.get(), synth.get(), analysisWidth, dt, band, constraint);
 		/*
 			6. Warp the synthesis TextGrid
-			First make domains equal, otherwsise the warper protests
+			First make domains equal, otherwise the warper protests
 		*/
         autoTextGrid warp = DTW_TextGrid_to_TextGrid (dtw.get(), tg_syn.get(), precision);
 		/*

--- a/dwtools/TableOfReal_extensions.cpp
+++ b/dwtools/TableOfReal_extensions.cpp
@@ -31,7 +31,7 @@
  djmw 20050221 TableOfReal_meansByRowLabels, extra reduce parameter.
  djmw 20050222 TableOfReal_drawVectors didn't draw rowlabels.
  djmw 20050512 TableOfReal TableOfReal_meansByRowLabels crashed if first label in sorted was NULL.
- djmw 20051116 TableOfReal_drawScatterPlot draw reverse permited by choosing xmin > xmax and/or ymin>ymax
+ djmw 20051116 TableOfReal_drawScatterPlot draw reverse permitted by choosing xmin > xmax and/or ymin>ymax
  djmw 20060301 TableOfReal_meansByRowLabels extra medianize
  djmw 20060626 Extra NULL argument for ExecRE.
  djmw 20070822 wchar

--- a/dwtools/TableOfReal_extensions.h
+++ b/dwtools/TableOfReal_extensions.h
@@ -218,7 +218,7 @@ double TableOfReal_testCovarianceEqualsIdentityMatrix (TableOfReal me, integer n
 double TableOfReal_testCovarianceCompoundSymmetry (TableOfReal me, integer numberOfPermutations, bool useCorrelation);
 /*
 	H0: Sigma = sigma^2 (1-rho) * I + rho * J,
-	where I is identity matrix and J is sqaure matrix of ones znd rho > 0 (intra-class correlation coefficient
+	where I is identity matrix and J is square matrix of ones znd rho > 0 (intra-class correlation coefficient
 	This is test3 in:
 		L. Wu, C. Weng, X. Wang, K. Wang & X. Liu (2018): Test of covariance and correlation matrices,
 		arXiv: 1812.01172v1 [start.ME] 4 Dec 2018.

--- a/dwtools/VowelEditor.cpp
+++ b/dwtools/VowelEditor.cpp
@@ -1263,7 +1263,7 @@ void structVowelEditor :: v_createChildren ()
 	publishButton = GuiButton_createShown (our windowForm, left, right, top, bottom, U"Publish", gui_button_cb_publish, this, 0);
 	/*
 		Four Text widgets with the label on top: Duration, Extend, f0, Slope.
-		Make the f0 slope button 10 wider to accomodate the text
+		Make the f0 slope button 10 wider to accommodate the text
 		We wil not use a callback from a Text widget. It will get called multiple times during the editing
 		of the text. Better to have all editing done and then query the widget for its value!
 	*/

--- a/dwtools/manual_BSS.cpp
+++ b/dwtools/manual_BSS.cpp
@@ -69,7 +69,7 @@ DEFINITION (U"the standard deviation of the noise that is added to each transfor
 	"diagonalizable anymore.")
 ENTRY (U"Algorithm")
 NORMAL (U"All the CrossCorrelationTable matrices are generated as #%V\\'p #%D__%k_ #%V, where #%D__%k_ is a diagonal matrix "
-	"with entries randomly choosen from the [-1,1] interval. The matrix #%V is a \"random\" orthogonal matrix "
+	"with entries randomly chosen from the [-1,1] interval. The matrix #%V is a \"random\" orthogonal matrix "
 	"obtained from the singular value decomposition of a matrix #%M = #%U #%D #%V\\'p, where the cells of the "
 	"matrix #%M are random Gaussian numbers with mean 0 and standard deviation 1.")
 NORMAL (U"If the first matrix has to be positive definite, the numbers on the diagonal of #%D__1_ are randomly "

--- a/dwtools/manual_HMM.cpp
+++ b/dwtools/manual_HMM.cpp
@@ -81,7 +81,7 @@ INTRO (U"Splits one component of the selected  @GaussianMixture into two compone
 NORMAL (U"The selected component is split on the basis of a @PCA analysis of its covariance matrix. The new means are situated "
 	"around the old components mean, 1%\\si apart in the first principal components direction, and the new covariances are "
 	"constructed with information from the old covariance matrix. ")
-NORMAL (U"The details of the algorith are described in @@Zhang et al. (2003)@.")
+NORMAL (U"The details of the algorithm are described in @@Zhang et al. (2003)@.")
 MAN_END
 
 MAN_BEGIN (U"GaussianMixture: To PCA", U"djmw", 20101030)
@@ -185,7 +185,7 @@ MAN_END
 MAN_BEGIN (U"GaussianMixture & TableOfReal: Improve likelihood...", U"djmw", 20111130)
 INTRO (U"Try to improve the likelihood of the parameters in the @@GaussianMixture@ by an @@expectation-maximization@ algorithm.")
 ENTRY (U"Settings & EM Algorithm")
-NORMAL (U"As decribed in @@TableOfReal: To GaussianMixture...@.")
+NORMAL (U"As described in @@TableOfReal: To GaussianMixture...@.")
 MAN_END
 
 MAN_BEGIN (U"GaussianMixture & TableOfReal: To Correlation (columns)", U"djmw", 20101111)
@@ -222,7 +222,7 @@ TERM (U"##Stability coefficient lambda")
 DEFINITION (U"defines the fraction of the total covariance that is added to the covariance of each component to "
 	"prevent these matrices from becoming singular.")
 TERM (U"##Criterion based on")
-DEFINITION (U"defines whether the function to be optimized is the log likelihood or the related miminum description length.")
+DEFINITION (U"defines whether the function to be optimized is the log likelihood or the related minimum description length.")
 ENTRY (U"Algorithm")
 NORMAL (U"The component-wise optimization algorithm is described in @@Figueiredo & Jain (2002)@ where the function to be optimized "
 	"is the minimum description length defined as:")

--- a/dwtools/manual_KlattGrid.cpp
+++ b/dwtools/manual_KlattGrid.cpp
@@ -143,7 +143,7 @@ DEFINITION (U"defines the distances between the following formants in hertz. For
 	"If the value is not positive these formants will not be created at all. You would typically choose this value "
 	"as 1000 / 1100 Hz for a male / female voice." )
 ENTRY (U"Examples")
-NORMAL (U"The following script creates a vowel sound with many formants wich will sound like the vowel /a/. "
+NORMAL (U"The following script creates a vowel sound with many formants which will sound like the vowel /a/. "
 	"The formant frequencies will be: F1 = 800 Hz, F2 = 1200 Hz, F3 = 2300 Hz, F4 = 2800 Hz. The frequencies of the higher "
 	"formants will be at intervals of 1000 Hz, starting from F4. Therefore, F5 = 3800 Hz, F6 = 4800 Hz, F7 = 5800 Hz, "
 	"and so on. The bandwidths will be B1 = 80 Hz, B2 = 80 Hz, B3 = 100 Hz. "
@@ -169,8 +169,8 @@ CODE (U"To Sound")
 NORMAL (U"An /au/ diphthong is also easily made by a simple extension with two oral formant frequency points:")
 CODE (U"Create KlattGrid from vowel: \"au\", 0.3, 125, 800, 80, 1200, 80, 2300, 100, 2800, 0.05, 1000")
 CODE (U"Add pitch point: 0.3, 100.0")
-CODE (U"Add oral formant frequncy point: 1, 0.3, 300")
-CODE (U"Add oral formant frequncy point: 2, 0.3, 600")
+CODE (U"Add oral formant frequency point: 1, 0.3, 300")
+CODE (U"Add oral formant frequency point: 2, 0.3, 600")
 CODE (U"To Sound")
 NORMAL (U"Formant frequencies and bandwidths for 16 Swedish vowels are presented by "
 	"@@Hawks & Miller (1995)@ in their table 1. They further give equations for bandwidths as a function "

--- a/dwtools/manual_MDS.cpp
+++ b/dwtools/manual_MDS.cpp
@@ -761,7 +761,7 @@ DEFINITION (U"determines the handling of ties in the data. In the %%primary appr
 	"two or more dissimilarities are equal we do not care whether the fitted "
 	"distances are equal or not. "
 	"Consequently, no constraints are imposed on the fitted distances. "
-	"For the %%secondary approach%, however, we impose the constaint that the fitted distances be "
+	"For the %%secondary approach%, however, we impose the constraint that the fitted distances be "
 	"equal whenever the dissimilarities are equal.")
 NORMAL (U"For the calculation of stress:")
 TERM (U"##Kruskal's stress-1 (Formula1, the default)")   // ??
@@ -1446,7 +1446,7 @@ NORMAL (U"Select the Dissimilarity and the Configuration together to "
 PICTURE (4.0, 4.0, drawLetterRRegression)
 NORMAL (U"The following script summarizes:")
 CODE (U"selectObject: dissimilarity, configuration")
-CODE (U"Draw monotone regresion: \"Primary approach\", 0, 200, 0, 2.2, 1, \"+\", \"yes\"")
+CODE (U"Draw monotone regression: \"Primary approach\", 0, 200, 0, 2.2, 1, \"+\", \"yes\"")
 NORMAL (U"When you enter %noiseRange = 0 in the form for the letter #R, perfect "
 	"reconstruction is possible. The Shepard diagram then will show "
 	"a perfectly smooth monotonically increasing function.")

--- a/dwtools/manual_Permutation.cpp
+++ b/dwtools/manual_Permutation.cpp
@@ -89,7 +89,7 @@ DEFINITION (U"the name of the new permutation.")
 TERM (U"##Number of elements%")
 DEFINITION (U"the number of elements in the permutation.")
 TERM (U"##Identity permutation")
-DEFINITION (U"determines whether the permution will be a randomly chosen one, or the @@identity permutation@.")
+DEFINITION (U"determines whether the permutation will be a randomly chosen one, or the @@identity permutation@.")
 MAN_END
 
 MAN_BEGIN (U"identity permutation", U"djmw", 20050713)

--- a/dwtools/manual_dwtools.cpp
+++ b/dwtools/manual_dwtools.cpp
@@ -356,7 +356,7 @@ NORMAL (U"A ##canonical variate# is a new variable (variate) formed by making a 
 	"Because we can in infinitely many ways choose combinations of weights between variables in a data set, "
 	"there are also infinitely many canonical variates possible. ")
 NORMAL (U"In general additional constraints should be satisfied by the weights to get a meaningful canonical variate. "
-	"For example, in @@Canonical correlation analysis|canonical correlation analyis@ a data set is split up into two parts, a %%dependent% and an %%independent% part. "
+	"For example, in @@Canonical correlation analysis|canonical correlation analysis@ a data set is split up into two parts, a %%dependent% and an %%independent% part. "
 	"In both parts we can form a canonical variate and we choose weights that maximize the correlation between these canonical variates "
 	"(there is an @@TableOfReal: To CCA...|algorithm@ that calculates these weights).")
 MAN_END
@@ -953,7 +953,7 @@ INTRO (U"Increases the contents of cell(s) in the selected @@Confusion@. The cel
 	"@ClassificationTable.")
 ENTRY (U"Behaviour")
 NORMAL (U"For each row in the ClassificationTable object the contents of one cell in the Confusion we be increased by one. "
-	"This cell is determined as follows: we start by finding the label of the column wich the largest number in it. "
+	"This cell is determined as follows: we start by finding the label of the column which the largest number in it. "
 	"This label is defined as the ##response label#. We use the corresponding row label as the ##stimulus label#. The content "
 	"of the cell in the Confusion object whose row and column are labeled with ##stimulus label# and ##response label#, "
 	"respectively, is increased by one.")
@@ -1411,7 +1411,7 @@ DEFINITION (U"the number of frequency components in the tone complex.")
 TERM (U"##Frequency change (semitones/s)")
 DEFINITION (U"determines how many semitones the frequency of each component will change in one second. "
 	"The number of seconds needed to change one octave will then be 12 divided by ##Frequency change#. "
-	"You can make rising, falling and monotonous tone complexes by chosing a positive, negative or zero value.")
+	"You can make rising, falling and monotonous tone complexes by choosing a positive, negative or zero value.")
 TERM (U"##Amplitude range% (dB)")
 DEFINITION (U"determines the relative size in decibels of the maximum and the minimum amplitude of the components in a tone complex. These relative amplitudes will then be 10^^\\--%amplitudeRange/20^. ")
 TERM (U"##Octave shift fraction (0-1)")
@@ -2824,7 +2824,7 @@ MAN_END
 MAN_BEGIN (U"non-negative matrix factorization", U"djmw", 20191024)
 INTRO (U"The ##non-negative matrix factorization## or ##NMF# is a factorization of a data matrix #%D, whose elements are all non-negative, into a feature matrix #%F and a weights matrix #%W such that #%D \\~~ #%F #%W, where the elements of #%F and #%W are also all non-negative.")
 ENTRY (U"Algorithms for computing NMF")
-NORMAL (U"More backgroud on the algorithms used can be found in @@Berry et al. (2007)@")
+NORMAL (U"More background on the algorithms used can be found in @@Berry et al. (2007)@")
 NORMAL (U"The algorithms fall into three general classes:")
 TERM (U"##1. Multiplicative updates#,")
 TERM (U"##2. Alternating Least squares#,")
@@ -3098,7 +3098,7 @@ DEFINITION1 (U"the values are slopes in herz per second followed by an end frequ
 TERM1 (U"%%music notes%")
 DEFINITION1 (U"the values are music notes specified on the twelve tone scale as a0, a\\# 0, b0, c0, c\\# 0, d0, d\\# 0, e0, f0, "
 	"f\\# 0, g0, g\\# 0, a1, a\\# 1, ... a4, ..., or g\\# 9. Here the octave is indicated by the number, 0 being the lowest octave "
-	"and 9 the highest. The a4 is choosen to be at 440 Hz. Therefore, a0 is the note with the lowest frequency, four octaves below "
+	"and 9 the highest. The a4 is chosen to be at 440 Hz. Therefore, a0 is the note with the lowest frequency, four octaves below "
 	"the a4 and corresponds to a frequency of 27.5 Hz. As a scale of reference we give a0 = 27.5 Hz, a1 = 55 Hz, a2 = 110 Hz, "
 	"a3 = 220 Hz, a4 = 440 Hz, a5 = 880 Hz, a6 = 1760 Hz, a7 = 3520 Hz, a8 = 7040 Hz and a9 = 14080 Hz.")
 TERM (U"##...which is the...")
@@ -3811,7 +3811,7 @@ NORMAL (U"My info window shows:")
 NORMAL (U"-0.0563380281690141 -3.341667830688472e-17 0.7616819283108669")
 
 ENTRY (U"4.1.2 The solution of the regression without the constraint")
-NORMAL (U"No constraints are involed if we set %\\al = 0")
+NORMAL (U"No constraints are involved if we set %\\al = 0")
 CODE (U"x# = solveWeaklyConstrained# (a##, y#, 0.0, delta)")
 CODE (U"writeInfoLine: x#")
 NORMAL (U"My info window shows:")
@@ -4215,7 +4215,7 @@ TERM (U"##Shift by (Hz)")
 DEFINITION (U"the amount by which frequencies are shifted. A positive number shifts frequencies up, a negative number "
 	"shifts frequencies down. ")
 ENTRY (U"##Example")
-NORMAL (U"Rodents produce sounds with frequencies far outside the human audible range. Some meaningfull sqeeks of these animals "
+NORMAL (U"Rodents produce sounds with frequencies far outside the human audible range. Some meaningful squeaks of these animals "
 	"are present in the frequency range from 54 kHz up to sometimes 100kHz. By choosing a shift value of -54000 Hz and a sampling "
 	"frequency of 44100 Hz, all frequencies between 54000 Hz and (54000+22050=) 76050 Hz  will be shifted down by 54000 Hz. The "
 	"rodents’ frequencies in the interval from 54000 Hz to 76050 Hz will therefore be mapped to the frequency interval between 0 and 22050 Hz. ")
@@ -4555,7 +4555,7 @@ DEFINITION (U"the new absolute peak of the derivative. By specifying a value sma
 	"without distortion. If you want to listen to the derivative without distortion, it is absolutely necessary to scale the "
 	"peak to a value somewhat smaller than 1.0, like 0.99. For example, for a pure sine tone with a frequency of 300 Hz "
 	"and an amplitude of 1.0 whose formula is %%s(t) = sin(2\\pi300t)% the derivative with respect to time %t% is %%2\\pi300 cos(2\\pi300t)% ."
-	"The result is a cosine of 300 Hz with a huge amplitude of %%2\\pi300%. You can prevent any scaling by suppling a value of 0.0.")
+	"The result is a cosine of 300 Hz with a huge amplitude of %%2\\pi300%. You can prevent any scaling by supplying a value of 0.0.")
 ENTRY (U"Algorithm")
 NORMAL (U"The derivative of a wave form %%x%(%%t%) is most easily calculated in the spectral domain. According to "
 	"Fourier theory, if %%x%(%%t%) = \\in%%X%(%%f%)exp(2\\pi%%ift%) %%dt%, then"
@@ -5941,7 +5941,7 @@ DEFINITION (U"have the same meaning as defined above for the topic and before se
 TERM (U"##Context combination criterion#")
 DEFINITION (U"defines how the before and after sets have to be combined in the matching. The possible options are ##before#, or "
 	"##after# or ##before and after# or ##before or after, not both# or ##before or after, or both# or finally "
-	"##no before and no after#. Given the topic, before and after labels examples defined above, chosing ##before and after# "
+	"##no before and no after#. Given the topic, before and after labels examples defined above, choosing ##before and after# "
 	"would limit the search to vowels preceded by a plosive and followed by a nasal.")
 TERM (U"##Exclude topic labels boolean#")
 DEFINITION (U"when on, only the before and / or the after label set will be used in matching. Of course this effect "
@@ -6074,7 +6074,7 @@ NORMAL (U"The script starts by creating the navigator for the %topic tier, tier 
 	"##Add search tier# command which was chosen as ##overlaps before and after#. "
 	"Now, only if %tmin2 < %tmin1 and %tmax2 > %tmax1 the two intervals have the desired alignment and the match would succeed. ")
 NORMAL (U"We can, of course, make our match stricter and demand that, for example, the complete three phoneme match of the topic "
-	"tier is located within the match domain of the systax tier by issuing the following command:")
+	"tier is located within the match domain of the syntax tier by issuing the following command:")
 CODE (U"selectObject: navigator")
 CODE (U"Modify match domain: phonemeTierNumber, \"Before start to Topic end\"")
 NORMAL (U"Even more stricter to exact alignment:")

--- a/dwtools/praat_David_init.cpp
+++ b/dwtools/praat_David_init.cpp
@@ -34,7 +34,7 @@
  djmw 20040704 BarkFilter... in Thing_recognizeClassesByName.
  djmw 20041020 MelderFile -> structMelderFile.
  djmw 20041105 TableOfReal_createFromVanNieropData_25females.
- djmw 20041108 FormantFilter_drawSpectrum bug correted (wrong field name).
+ djmw 20041108 FormantFilter_drawSpectrum bug corrected (wrong field name).
  djmw 20050308 Find path (slopes), Find path (band)... and others.
  djmw 20050404 TableOfReal_appendColumns -> TableOfReal_appendColumnsMany
  djmw 20050406 Procrustus -> Prorustes
@@ -6061,7 +6061,7 @@ FORM (CONVERT_EACH_TO_ONE__Sound_to_Polygon, U"Sound: To Polygon", U"Sound: To P
 DO
 	CONVERT_EACH_TO_ONE (Sound)
 		Melder_require (channel > 0 && channel <= my ny,
-			U"The channel number should be bewteen 1 and ", my ny, U".");
+			U"The channel number should be between 1 and ", my ny, U".");
 		autoPolygon result = Sound_to_Polygon (me, channel, fromTime, toTime, ymin, ymax, connectionY);
 	CONVERT_EACH_TO_ONE_END (my name.get())
 }
@@ -6713,7 +6713,7 @@ FORM (QUERY_ONE_FOR_REAL__SSCP_getConcentrationEllipseArea, U"SSCP: Get sigma el
 DO
 	QUERY_ONE_FOR_REAL (SSCP)
 		const double result = SSCP_getConcentrationEllipseArea (me, numberOfSigmas, 0, xIndex, yIndex);
-	QUERY_ONE_FOR_REAL_END (U" (concentation ellipse area)")
+	QUERY_ONE_FOR_REAL_END (U" (concentration ellipse area)")
 }
 
 DIRECT (QUERY_ONE_FOR_REAL__SSCP_getDegreesOfFreedom) {

--- a/dwtools/praat_HMM_init.cpp
+++ b/dwtools/praat_HMM_init.cpp
@@ -477,7 +477,7 @@ FORM (MODIFY_FIRST_OF_ONE_AND_ALL__HMM_HMMObservationSequence_learn, U"HMM & HMM
 	OK
 DO
 	Melder_require (minimumProbability >= 0.0 && minimumProbability < 1.0,
-		U"The minimum probabilty should be in [0, 1).");
+		U"The minimum probability should be in [0, 1).");
 	MODIFY_FIRST_OF_ONE_AND_ALL (HMM, HMMObservationSequence)
 		HMM_HMMObservationSequenceBag_learn (me, (HMMObservationSequenceBag) & list, relativePrecision_log, minimumProbability, showProgress);
 	MODIFY_FIRST_OF_ONE_AND_ALL_END

--- a/dwtools/praat_MultiSampledSpectrogram.cpp
+++ b/dwtools/praat_MultiSampledSpectrogram.cpp
@@ -49,7 +49,7 @@ FORM (MODIFY_EACH_WEAK__MultiSampledSpectrogram_formula_part, U"MultiSampledSpec
 	REAL (fromTime, U"From time", U"0.0")
 	REAL (toTime, U"To time", U"0.0 (= all)")
 	REAL (fromFrequency, U"From frequency (Hz)", U"100.0")
-	REAL (toFrequency, U"To Frequncy (Hz)", U"200.0")
+	REAL (toFrequency, U"To frequency (Hz)", U"200.0")
 	FORMULA (formula, U"Formula", U"2 * self")
 	OK
 DO


### PR DESCRIPTION
Found via `codespell -q 3 -S external -L nd,shs`