### PR TITLE
Add a save as default button

### DIFF
--- a/foned/TextGridArea.cpp
+++ b/foned/TextGridArea.cpp
@@ -863,11 +863,24 @@ static void menu_cb_SaveWholeTextGridAsTextFile (TextGridArea me, EDITOR_ARGS) {
 		Data_writeToTextFile (my textGrid(), file);
 	EDITOR_END
 }
+
+static void menu_cb_SaveTextGridWithDefaultName (TextGridArea me, EDITOR_ARGS) {
+	EDITOR_FORM_SAVE (U"Save TextGrid with default name", nullptr)
+		Melder_sprint (defaultName,300, my textGrid() -> name.get(), U".TextGrid");
+	EDITOR_DO_SAVE_DEFAULT
+		Data_writeToTextFile (my textGrid(), file);
+	EDITOR_END
+}
+
 void structTextGridArea :: v_createMenuItems_save (EditorMenu menu) {
 	FunctionAreaMenu_addCommand (menu, U"- Save TextGrid to disk:", 0, nullptr, this);
 	FunctionAreaMenu_addCommand (menu,
 		U"Save whole TextGrid as text file... || Save TextGrid as text file... || Write TextGrid to text file...",
 		'S' | GuiMenu_DEPTH_1, menu_cb_SaveWholeTextGridAsTextFile, this
+	);
+	FunctionAreaMenu_addCommand (menu,
+		U"Save TextGrid with default name",
+		'S' | GuiMenu_OPTION | GuiMenu_DEPTH_1, menu_cb_SaveTextGridWithDefaultName, this
 	);
 }
 

--- a/sys/EditorM.h
+++ b/sys/EditorM.h
@@ -368,8 +368,8 @@ _form_inited_: \
 	if (! cmd -> d_uiform) { \
 		cmd -> d_uiform = UiOutfile_createE (cmd, title, cmd -> itemTitle.get(), helpTitle); \
 		} if (! _args_ && ! _sendingForm_ && ! _sendingString_) { char32 defaultName [300]; defaultName [0] = U'\0';
-#define EDITOR_DO_SAVE  \
-	UiOutfile_do (cmd -> d_uiform.get(), defaultName); } else { MelderFile file; structMelderFile _file2 { }; \
+#define _EDITOR_DO_SAVE(outfile_do) \
+	outfile_do (cmd -> d_uiform.get(), defaultName); } else { MelderFile file; structMelderFile _file2 { }; \
 	if (_args_) { \
 		Melder_require (_narg_ == 1, \
 			U"Command requires exactly 1 argument, the name of the file to write, instead of the given ", _narg_, U" arguments."); \
@@ -383,6 +383,8 @@ _form_inited_: \
 	} else { \
 		file = UiFile_getFile (cmd -> d_uiform.get()); \
 	}
+#define EDITOR_DO_SAVE _EDITOR_DO_SAVE(UiOutfile_do)
+#define EDITOR_DO_SAVE_DEFAULT _EDITOR_DO_SAVE(UiOutfile_do_default)
 
 #define EDITOR_FORM_READ(title, helpTitle)  \
 	if (! cmd -> d_uiform) { \

--- a/sys/Ui.h
+++ b/sys/Ui.h
@@ -343,6 +343,7 @@ autoUiForm UiOutfile_create (GuiWindow parent, Editor optionalEditor, conststrin
 void UiInfile_do (UiForm me);
 
 void UiOutfile_do (UiForm me, conststring32 defaultName);
+void UiOutfile_do_default (UiForm me, conststring32 defaultName);
 
 MelderFile UiFile_getFile (UiForm me);
 

--- a/sys/UiFile.cpp
+++ b/sys/UiFile.cpp
@@ -108,7 +108,24 @@ autoUiForm UiInfile_createE (EditorCommand cmd, conststring32 title, conststring
 }
 
 void UiOutfile_do (UiForm me, conststring32 defaultName) {
-	autostring32 outfileName = GuiFileSelect_getOutfileName (my d_dialogParent, my name.get(), defaultName);
+	autostring32 outfileName = Melder_dup(defaultName);
+	Melder_pathToFile (outfileName.get(), & my file);
+	structMelderFile file { };
+	MelderFile_copy (& my file, & file);   // save, because okCallback could destroy me
+	UiHistory_write (U"\n");
+	UiHistory_write_colonize (my invokingButtonTitle.get());
+	try {
+		my okCallback (me, 0, nullptr, nullptr, nullptr, my invokingButtonTitle.get(), false, my buttonClosure, my optionalEditor);
+	} catch (MelderError) {
+		Melder_flushError (U"File ", & file, U" not finished.");
+	}
+	UiHistory_write (U" \"");
+	UiHistory_write (outfileName.get());
+	UiHistory_write (U"\"");
+}
+
+void UiOutfile_do_default (UiForm me, conststring32 defaultName) {
+	autostring32 outfileName = Melder_dup(defaultName); //GuiFileSelect_getOutfileName (my d_dialogParent, my name.get(), defaultName);
 	if (! outfileName)
 		return;   // cancelled
 	if (my allowExecutionHook && ! my allowExecutionHook (my allowExecutionClosure)) {


### PR DESCRIPTION
I'm not a linguist but every linguist I know who uses Praat has wanted a button to just save by default and not go through an entire menu to do so.
So I have added this button.
It saves a file with the default filename into the current directory without checking whether one exists already.