### PR TITLE
Compliance with XDG specifications on UNIX systems

### DIFF
--- a/melder/melder_files.cpp
+++ b/melder/melder_files.cpp
@@ -540,9 +540,16 @@ void Melder_getParentPreferencesFolder (MelderFolder preferencesFolder) {
 		Melder_sprint (preferencesFolder -> path,kMelder_MAXPATH+1, homeFolder. path, U"/Library/Preferences");
 	#elif defined (UNIX)
 		/*
-			Preferences files go into the home folder.
+			Preferences files go into ${XDG_CONFIG_HOME}.
 		*/
-		Melder_getHomeDir (preferencesFolder);
+		structMelderFolder homeFolder { };
+		char *xdgConfigHome = getenv ("XDG_CONFIG_HOME");
+		if (!xdgConfigHome) {
+			Melder_getHomeDir (& homeFolder);
+			Melder_sprint (preferencesFolder -> path,kMelder_MAXPATH+1, homeFolder. path, U"/.config");
+		} else {
+			Melder_sprint (preferencesFolder -> path,kMelder_MAXPATH+1, Melder_peek8to32 (xdgConfigHome));
+		}
 	#elif defined (_WIN32)
 		/*
 			On Windows 95, preferences files went into the Windows folder.

--- a/sys/praat.cpp
+++ b/sys/praat.cpp
@@ -1442,7 +1442,7 @@ void praat_init (conststring32 title, int argc, char **argv)
 		*/
 		char32 subfolderName [256];
 		#if defined (UNIX)
-			Melder_sprint (subfolderName,256, U".", programName, U"-dir");   // for example .praat-dir
+			Melder_sprint (subfolderName,256, programName);   // for example praat
 		#elif defined (macintosh)
 			Melder_sprint (subfolderName,256, praatP.title.get(), U" Prefs");   // for example Praat Prefs
 		#elif defined (_WIN32)


### PR DESCRIPTION
Notice: this is a breaking change. Users need to move their files from `.praat-dir` to `.config/praat`.