### PR TITLE
Undo hardcoding of GUI background colour

### DIFF
--- a/sys/GuiDialog.cpp
+++ b/sys/GuiDialog.cpp
@@ -70,8 +70,6 @@ GuiDialog GuiDialog_create (GuiWindow parent, int x, int y, int width, int heigh
 	}
 	#if gtk
 		my d_gtkWindow = (GtkWindow *) gtk_dialog_new ();
-		static const GdkRGBA backgroundColour { 0.92, 0.92, 0.92, 1.0 };
-		gtk_widget_override_background_color (GTK_WIDGET (my d_gtkWindow), GTK_STATE_FLAG_NORMAL, & backgroundColour);
 		if (parent) {
 			Melder_assert (parent -> d_widget);
 			GuiObject toplevel = gtk_widget_get_ancestor (GTK_WIDGET (parent -> d_widget), GTK_TYPE_WINDOW);

--- a/sys/GuiWindow.cpp
+++ b/sys/GuiWindow.cpp
@@ -134,8 +134,6 @@ GuiWindow GuiWindow_create (int x, int y, int width, int height, int minimumWidt
 		(void) flags;
 		GuiGtk_initialize ();
 		my d_gtkWindow = (GtkWindow *) gtk_window_new (GTK_WINDOW_TOPLEVEL);
-		static const GdkRGBA backgroundColour { 0.92, 0.92, 0.92, 1.0 };
-		gtk_widget_override_background_color (GTK_WIDGET (my d_gtkWindow), GTK_STATE_FLAG_NORMAL, & backgroundColour);
 		g_signal_connect (G_OBJECT (my d_gtkWindow), "delete-event", goAwayCallback ? G_CALLBACK (_GuiWindow_goAwayCallback) : G_CALLBACK (gtk_widget_hide_on_delete), me.get());
 		g_signal_connect (G_OBJECT (my d_gtkWindow), "destroy-event", G_CALLBACK (_GuiWindow_destroyCallback), me.get());
 


### PR DESCRIPTION
This looks to address #2795 by undoing  1cf3e2d. Please review because there may be a reason that I've not seen for why the background was hardcoded...
