### PR TITLE
external/vorbis/Makefile remove duplicate object file

### DIFF
--- a/external/vorbis/Makefile
+++ b/external/vorbis/Makefile
@@ -7,7 +7,7 @@ CPPFLAGS = -I ../../melder
 
 OBJECTS = ogg_bitwise.o ogg_framing.o \
 	vorbis_block.o vorbis_bitrate.o vorbis_codebook.o vorbis_envelope.o vorbis_floor0.o \
-	vorbis_info.o vorbis_mdct.o vorbisfile.o vorbis_floor0.o vorbis_floor1.o vorbis_lpc.o vorbis_lsp.o \
+	vorbis_info.o vorbis_mdct.o vorbisfile.o vorbis_floor1.o vorbis_lpc.o vorbis_lsp.o \
 	vorbis_mapping0.o vorbis_psy.o vorbis_registry.o vorbis_res0.o vorbis_sharedbook.o vorbis_smallft.o \
 	vorbis_synthesis.o vorbis_window.o
 


### PR DESCRIPTION
vorbis_floor0.o appeared 2 times in the OBJECTS list

It doesn't affect build in the current state.

I noticed it as building all the current .a file as .so (reduce drastically linking time when developping).
There will be a linking error if you try to compile a .so with duplicate .o files.