### PR TITLE
docs(manual/Shimmer): fix heading 'Shimmer (ddp)' -> 'Shimmer (dda)'

### DIFF
--- a/docs/manual/Voice_3__Shimmer.html
+++ b/docs/manual/Voice_3__Shimmer.html
@@ -22,7 +22,7 @@ Voice 3. Shimmer
 <p>This is the five-point Amplitude Perturbation Quotient, the average absolute difference between the amplitude of a period and the average of the amplitudes of it and its four closest neighbours, divided by the average amplitude.</p>
 <h2>Shimmer (apq11)</h2>
 <p>This is the 11-point Amplitude Perturbation Quotient, the average absolute difference between the amplitude of a period and the average of the amplitudes of it and its ten closest neighbours, divided by the average amplitude. MDVP calls this parameter <i>APQ</i>, and gives 3.070% as a threshold for pathology.</p>
-<h2>Shimmer (ddp)</h2>
+<h2>Shimmer (dda)</h2>
 <p>This is the average absolute difference between consecutive differences between the amplitudes of consecutive periods. This is Praat's original <b>Get shimmer</b>. The value is three times APQ3.</p>
 <h3>Links to this page</h3>
 <ul>


### PR DESCRIPTION
Fixes #3225.

Reporter noted `docs/manual/Voice_3__Shimmer.html` has a heading `Shimmer (ddp)` which should be `Shimmer (dda)` — the content underneath matches DDA (Difference of Differences of Amplitudes), and the Voice-report runtime output uses `Shimmer (dda)` + `Jitter (ddp)` consistently.

Single-character heading fix, docs-only.

```diff
- <h2>Shimmer (ddp)</h2>
+ <h2>Shimmer (dda)</h2>
```