### PR TITLE
Add keyboard shortcut for formant listing

### DIFF
--- a/docs/manual/Keyboard_shortcuts.html
+++ b/docs/manual/Keyboard_shortcuts.html
@@ -67,6 +67,7 @@ Keyboard shortcuts
 <dd style="position:relative;padding-left:1em;text-indent:-2em">Shift-Command-?: Local help</dd>
 <dd style="position:relative;padding-left:1em;text-indent:-2em">Command-,: Move start of selection to nearest zero crossing</dd>
 <dd style="position:relative;padding-left:1em;text-indent:-2em">Command-.: Move end of selection to nearest zero crossing</dd>
+<dd style="position:relative;padding-left:1em;text-indent:-2em">Command-F1: Formant listing</dd>
 <dd style="position:relative;padding-left:1em;text-indent:-2em">F1: Get first formant</dd>
 <dd style="position:relative;padding-left:1em;text-indent:-2em">F2: Get second formant</dd>
 <dd style="position:relative;padding-left:1em;text-indent:-2em">F3: Get third formant</dd>

--- a/foned/SoundAnalysisArea.cpp
+++ b/foned/SoundAnalysisArea.cpp
@@ -2318,7 +2318,7 @@ void structSoundAnalysisArea :: v_createMenuItems_formant (EditorMenu menu) {
 			0, menu_cb_advancedFormantSettings, this);
 
 	FunctionAreaMenu_addCommand (menu, U"- Query formants:", 0, nullptr, this);
-	FunctionAreaMenu_addCommand (menu, U"Formant listing", 1,
+	FunctionAreaMenu_addCommand (menu, U"Formant listing", GuiMenu_COMMAND | GuiMenu_F1 | GuiMenu_DEPTH_1,
 			INFO_DATA__formantListing, this);
 	FunctionAreaMenu_addCommand (menu, U"Get first formant", GuiMenu_F1 | GuiMenu_DEPTH_1,
 			QUERY_DATA_FOR_REAL__getFirstFormant, this);


### PR DESCRIPTION
Extremely simple PR, I just find it useful when I'm doing enough formants to get tired of clicking everywhere to find the formant listing but not enough to do the work of automating it. Ctrl+F1 seems like a reasonable shortcut, since other formant shortcuts use the F keys, and it didn't seem to be used by anything else.