### PR TITLE
Do not use URL in description paragraph

### DIFF
--- a/org.praat.Praat.metainfo.xml
+++ b/org.praat.Praat.metainfo.xml
@@ -207,7 +207,7 @@
       <url type="details">https://github.com/praat/praat.github.io/releases/tag/v6.4.50</url>
       <description>
         <ul>
-          <li>A bit of speech recognition via Whisper.cpp (adapted to Praat by Anastasia Shchupak), such as **Transcribe interval** in the TextGrid window. This works after you install one or more Whisper-cpp models, such as `ggml-base.bin` (from `https://huggingface.co/ggerganov/whisper.cpp`) in the `models` subfolder of the preferences folder.</li>
+          <li>A bit of speech recognition via Whisper.cpp (adapted to Praat by Anastasia Shchupak), such as **Transcribe interval** in the TextGrid window. This works after you install one or more Whisper-cpp models, such as Georgi Gerganov's `ggml-base.bin` in the `models` subfolder of the preferences folder.</li>
         </ul>
       </description>
     </release>


### PR DESCRIPTION
According to the [Upstream Metadata standards](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html), URLs are not allowed in the description paragraphs.

The previous version of org.praat.Praat.metainfo.xml did not pass validation:

```
appstreamcli validate ./org.praat.Praat.metainfo.xml
W: org.praat.Praat:209: description-has-plaintext-url ul
```

Enclosing the URL in a <usr> tag makes things worse:
```
appstreamcli validate ./org.praat.Praat.metainfo.xml
E: org.praat.Praat:210: description-para-markup-invalid url
```