### PR TITLE
Add copyright holder the metainfo file

### DIFF
--- a/org.praat.Praat.metainfo.xml
+++ b/org.praat.Praat.metainfo.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2026 LinuxSBC <anna@simmons.ovh>
+SPDX-License-Identifier: MIT
+-->
 <component type="desktop-application">
   <id>org.praat.Praat</id>
   


### PR DESCRIPTION
The` org.praat.Praat.metainfo.xml` file contains a `<metada_license>` tag. Unfortunately, the Upstream Metadata standard has no provision for indicating the Copyright holder.

The KDE community [recommends](https://community.kde.org/Guidelines_and_HOWTOs/Licensing#Other_XML_Files_%28appdata.xml%2C_%2A.qrc%29) using `SPDX-FileCopyrightText` and `SPDX-License-Identifier` for XML files, following the [SPDX specifications](https://spdx.github.io/spdx-spec/v2.3/file-tags/).

This issue arose when building the Debian package for Praat, because every file must have an identified Copyright holder.

The name an email of the Copyright holder is inferred from the commits that created and modified the  `org.praat.Praat.metainfo.xml` file (e06cef2dc2299c3c249d8f57db40c945b807ff7e and a12f3c875986f3812b022ee9cd001ca4b60ab6e8).