### PR TITLE
Honor the external definitions of CFLAGS, CXXFLAGS, and LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ all: all-external all-self
 		external/opusfile/libopusfile.a \
 		external/whispercpp/libwhisper.a \
 		external/blake3/libblake3.a \
-		$(NON_PRAAT_LIBRARIES)
+               $(NON_PRAAT_LIBRARIES) $(LDFLAGS)
 
 all-external:
 	$(MAKE) -C external/clapack

--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,8 @@ else ifeq ($(OS_IS_LINUX),1)
     SHARED_COMPILER_FLAGS += -Dchrome
   endif
 
-  CFLAGS := -std=gnu99 $(SHARED_COMPILER_FLAGS) -Werror=missing-prototypes -Werror=implicit
-  CXXFLAGS := -std=c++17 $(SHARED_COMPILER_FLAGS) -Wshadow
+  CFLAGS += -std=gnu99 $(SHARED_COMPILER_FLAGS) -Werror=missing-prototypes -Werror=implicit
+  CXXFLAGS += -std=c++17 $(SHARED_COMPILER_FLAGS) -Wshadow
 
   ifeq ($(PRAAT_COMPILER),clang)
     CC := clang


### PR DESCRIPTION
This issue arose in the context of building the Debian praat package. In Debian, some hardening options (obtained from `dpkg-buildflags`) must be included the `CFLAGS` and `CXXFLAGS` variables in the Makefile. This patch makes this possible by changing the assignments from `:=` to `+=`.

Note that only the section for Linux has been changed. Similar changes for other OS' may be appropriate.

A second commit in this PR adds `$(LDFLAGS)` to the compilation command for the praat executable.