### PR TITLE
Add Github Actions workflow to build and test Praat

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,14 +14,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libasound2-dev libpulse-dev libjack-dev cage
-
     - name: Compile binary
-      run: make
+      run: make PRAAT_GRAPHICS=barren PRAAT_AUDIO=none
 
     - name: Run test script
-      run: |
-          WLR_BACKENDS=headless cage -- ./praat --FULL-TRUST --run test/runAllTests_batch.praat
-          # Praat requires a display server, even if the GUI doesn't launch.
-          # cage is a simple Wayland compositor, and WLR_BACKENDS=headless means it doesn't need a physical screen.
+      run: ./praat_barren --FULL-TRUST --run test/runAllTests_batch.praat

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,5 +17,8 @@ jobs:
     - name: Compile binary
       run: make PRAAT_GRAPHICS=barren PRAAT_AUDIO=none
 
-    - name: Run test script
+    - name: Run /test scripts
       run: ./praat_barren --FULL-TRUST --run test/runAllTests_batch.praat
+
+    - name: Run /dwtest scripts
+      run: ./praat_barren --FULL-TRUST --run dwtest/runAllTests_batch.praat

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,25 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt-get install -y libgtk-3-dev libasound2-dev libpulse-dev libjack-dev xvfb
+
+    - name: Compile binary
+      run: make
+
+    - name: Run test script
+      run: |
+          xvfb-run --auto-servernum ./praat --FULL-TRUST --run test/runAllTests_batch.praat

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,11 +15,11 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install -y libgtk-3-dev libasound2-dev libpulse-dev libjack-dev xvfb
+      run: sudo apt-get install -y libgtk-3-dev libasound2-dev libpulse-dev libjack-dev cage
 
     - name: Compile binary
       run: make
 
     - name: Run test script
       run: |
-          xvfb-run --auto-servernum ./praat --FULL-TRUST --run test/runAllTests_batch.praat
+          WLR_BACKENDS=headless cage -- ./praat --FULL-TRUST --run test/runAllTests_batch.praat

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install -y libgtk-3-dev libasound2-dev libpulse-dev libjack-dev cage
+      run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libasound2-dev libpulse-dev libjack-dev cage
 
     - name: Compile binary
       run: make

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,3 +23,5 @@ jobs:
     - name: Run test script
       run: |
           WLR_BACKENDS=headless cage -- ./praat --FULL-TRUST --run test/runAllTests_batch.praat
+          # Praat requires a display server, even if the GUI doesn't launch.
+          # cage is a simple Wayland compositor, and WLR_BACKENDS=headless means it doesn't need a physical screen.


### PR DESCRIPTION
This was requested by the Flathub reviewers before Praat could be submitted to Flathub.

This basically means that, on every push and PR, Github will automatically compile Praat and run all tests on their servers so you can see if there are any issues. You can see exactly what it does in the YAML file; it's pretty self-explanatory, with one exception: the `cage` command.

Praat's GTK backend tries to bind to a display server even if the GUI doesn't actually launch, but Github's servers don't have those and the Praat test suite crashes. To solve this, `cage` makes a simple Wayland server that Praat can run in, and the `WLR_BACKENDS=headless` variable allows it to run without a physical display. If you're familiar with the `xvfb-run` command, this is basically that but with Wayland compatibility for when GTK eventually drops X11 support.

If you want to see how a workflow run looks, here's the most recent one from my repo where I was testing this: https://github.com/LinuxSBC/praat/actions/runs/29389368317/job/87269181483