### PR TITLE
Update metainfo.xml to match v6.6.30

### DIFF
--- a/org.praat.Praat.metainfo.xml
+++ b/org.praat.Praat.metainfo.xml
@@ -72,6 +72,16 @@ SPDX-License-Identifier: MIT
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="6.6.30" date="2026-06-30">
+      <url type="details">https://github.com/praat/praat.github.io/releases/tag/v6.6.30</url>
+      <description>
+        <ul>
+          <li>Tutorial documentation on speech recognition.</li>
+          <li>Removed a crashing bug when cross-correlating or convolving two MFCC objects.</li>
+          <li>A bit of spectrogram colouring.</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.4.67" date="2026-05-21">
       <url type="details">https://github.com/praat/praat.github.io/releases/tag/v6.4.67</url>
       <description>


### PR DESCRIPTION
This just adds the new version to the metainfo.xml file. I'll be faster on this in the future, I just didn't think it was worth updating until I got the rest of my Flathub changes working.