### PR TITLE
Add Flathub verification

### DIFF
--- a/docs/.well-known/org.flathub.VerifiedApps.txt
+++ b/docs/.well-known/org.flathub.VerifiedApps.txt
@@ -1,0 +1,2 @@
+# org.praat.Praat
+74bb986f-85a1-4558-ac59-a6010f70842d


### PR DESCRIPTION
Praat has now been accepted to Flathub! https://flathub.org/en/apps/org.praat.Praat

Now, to mark that this was done in collaboration with the Praat developers, I'd like to mark the package as Verified. That requires adding a specific token to the website, which is done in this PR.